### PR TITLE
feat(calendario): Implement real-time shift counts and fix email error

### DIFF
--- a/app/calendario/templates/calendario/shift_manager.html
+++ b/app/calendario/templates/calendario/shift_manager.html
@@ -63,14 +63,14 @@
 {% endfor %}
 </div>
 
-<div class="employee-stats-summary" style="margin-bottom: 15px; padding: 10px; border: 1px solid #ccc; border-radius: 5px;">
+<div class="employee-stats-summary" data-current-month="{{ month.strftime('%Y-%m') }}" style="margin-bottom: 15px; padding: 10px; border: 1px solid #ccc; border-radius: 5px;">
     <h3 style="margin-top: 0;">今月の集計</h3>
     {% if employees %}
         {% for emp in employees %}
             <p style="margin: 5px 0;">
                 {{ emp }}:
-                勤務日数 {{ counts.get(emp, 0) }}日,
-                休日数 {{ off_counts.get(emp, 0) }}日
+                勤務日数 <span class="work-count" data-emp="{{ emp }}">{{ counts.get(emp, 0) }}</span>日,
+                休日数 <span class="off-count" data-emp="{{ emp }}">{{ off_counts.get(emp, 0) }}</span>日
             </p>
         {% endfor %}
     {% else %}


### PR DESCRIPTION
This commit introduces two main improvements to the Clendario shift management:

1.  **Real-time Shift Count Updates:**
    -   The number of holidays and workdays for each employee now updates
        dynamically on the shift management page as shifts are dragged
        and dropped.
    -   A new API endpoint `/api/calendario/recalculate_shift_counts` has
        been added. This endpoint recalculates shift statistics based on
        the provided assignments without persisting changes, allowing for
        a real-time preview.
    -   `static/js/shift_manager.js` has been updated to call this API
        after each drag-and-drop operation and refresh the displayed counts.
    -   `app/calendario/templates/calendario/shift_manager.html` has been
        modified to include necessary IDs and classes for the JavaScript
        to update the count elements.

2.  **Email Notification Error Fix:**
    -   The issue causing a `[WinError 10061] Connection refused` error
        when clicking the "完成" (Complete) button has been resolved.
    -   Email notifications (via `utils._notify_all`) are now strictly
        conditional and will only be attempted if the "告知" (Notify)
        button is pressed. No email attempt is made when "完成" (Complete)
        is pressed.
    -   Error handling (try-except) has been added around the notification
        call in `app/calendario/routes.py` for robustness.

Additionally, Python unit tests have been added for the new API endpoint to ensure its correctness. Manual testing instructions were formulated for the UI changes.