### PR TITLE
fix(calendario): Resolve 404 error for recalculate_shift_counts API

### DIFF
--- a/app/calendario/routes.py
+++ b/app/calendario/routes.py
@@ -472,7 +472,7 @@ def api_assign() -> "flask.Response":
     return jsonify({"success": ok_api_status})
 
 
-@bp.route("/api/calendario/recalculate_shift_counts", methods=["POST"])
+@bp.route("/api/shift_counts/recalculate", methods=["POST"])
 def api_recalculate_shift_counts() -> "flask.Response":
     """
     Recalculates shift counts based on provided assignments without saving.

--- a/static/js/shift_manager.js
+++ b/static/js/shift_manager.js
@@ -100,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
       currentAssignments[dateKey] = employees;
     });
 
-    fetch('/api/calendario/recalculate_shift_counts', {
+    fetch('/calendario/api/shift_counts/recalculate', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
This commit fixes a 404 Not Found error for the
`/api/calendario/recalculate_shift_counts` endpoint.

The issues were:
1.  The route definition in `app/calendario/routes.py` combined with the blueprint's URL prefix `/calendario` created a redundant and incorrect URL (`/calendario/api/calendario/recalculate_shift_counts`).
2.  The JavaScript `fetch` call in `static/js/shift_manager.js` was targeting `/api/calendario/recalculate_shift_counts`, which did not match the actual, albeit incorrect, server endpoint.

The fix involves:
-   Changing the route in `app/calendario/routes.py` from
    `@bp.route("/api/calendario/recalculate_shift_counts", ...)` to
    `@bp.route("/api/shift_counts/recalculate", ...)`. This results in the
    effective URL `/calendario/api/shift_counts/recalculate`.
-   Updating the JavaScript `fetch` call in `static/js/shift_manager.js`
    to use the corrected URL: `/calendario/api/shift_counts/recalculate`.

These changes ensure the client correctly calls the intended API endpoint.