### PR TITLE
feat: Implement enhanced Seminario and Calendario features

### DIFF
--- a/app/Seminario/forms.py
+++ b/app/Seminario/forms.py
@@ -1,15 +1,22 @@
 """Forms for Seminario blueprint."""
 
 from flask_wtf import FlaskForm
-from wtforms import DateField, StringField, TextAreaField, SubmitField
+from wtforms import DateField, StringField, TextAreaField, SubmitField, SelectField
 from wtforms.validators import DataRequired
 
 
 class LessonScheduleForm(FlaskForm):
     """Form to register lesson schedule."""
 
-    date = DateField("受講予定日", validators=[DataRequired()])
-    title = StringField("レッスン名", validators=[DataRequired()])
+    date = DateField("開始日", validators=[DataRequired()]) # Changed label from "受講予定日"
+    title = StringField("タイトル", validators=[DataRequired()]) # Changed label from "レッスン名"
+    seminar_end_date = DateField("終了日", validators=[DataRequired()])
+    calendar_event_type = SelectField(
+        "種別",
+        choices=[('kouza', '講座')],
+        default='kouza',
+        validators=[DataRequired()]
+    )
     submit = SubmitField("登録")
 
 

--- a/app/Seminario/routes.py
+++ b/app/Seminario/routes.py
@@ -1,24 +1,28 @@
 """Routes for Seminario blueprint."""
 
 from flask import render_template, session, redirect, url_for, flash, request
+from datetime import date # For feedback deadline check
 
 from . import bp
-from .forms import LessonScheduleForm, LessonFeedbackForm
+# LessonFeedbackForm is no longer used for a dedicated page/route
+from .forms import LessonScheduleForm
 from . import utils
 
 
 @bp.before_request
 def require_login():
     if "user" not in session:
+        # Pass the original URL to the login page for redirection after login
         return redirect(url_for("auth.login", next=request.url))
 
 
 @bp.route("/")
 def index():
     user = session.get("user")
-    entries = utils.load_entries()
-    entries.sort(key=lambda e: e.get("lesson_date"))
-    return render_template("seminario_list.html", entries=entries, user=user)
+    entries = utils.get_active_seminars()
+    # Sort by lesson_date (start date), newest first. Ensure robust sorting.
+    entries.sort(key=lambda e: e.get("lesson_date") or "", reverse=True)
+    return render_template("seminario/seminario_list.html", entries=entries, user=user)
 
 
 @bp.route("/schedule", methods=["GET", "POST"])
@@ -26,23 +30,131 @@ def schedule():
     user = session.get("user")
     form = LessonScheduleForm()
     if form.validate_on_submit():
-        utils.add_schedule(user["username"], form.date.data, form.title.data)
-        flash("登録しました")
-        return redirect(url_for("seminario.index"))
-    return render_template("seminario_schedule_form.html", form=form, user=user)
+        # Note: form.seminar_end_date and form.calendar_event_type
+        # are expected to be added to LessonScheduleForm in a later task.
+        # The order of arguments matches the definition in utils.add_schedule:
+        # (author, lesson_date, title, calendar_event_type, seminar_end_date)
+        utils.add_schedule(
+            author=user["username"],
+            lesson_date=form.date.data,  # This is the seminar start date
+            title=form.title.data,
+            calendar_event_type=form.calendar_event_type.data,
+            seminar_end_date=form.seminar_end_date.data,
+        )
+        flash("新しいセミナーを登録しました。", "success")
+        return redirect(url_for(".index"))
+    return render_template("seminario/seminario_schedule_form.html", form=form, user=user)
 
 
-@bp.route("/feedback/<int:entry_id>", methods=["GET", "POST"])
-def feedback(entry_id: int):
+# The old feedback(entry_id) route has been removed.
+# Its functionality is replaced by feedback_submission_page and submit_feedback_for_seminar.
+
+
+@bp.route("/confirm")
+def confirm_list():
     user = session.get("user")
-    form = LessonFeedbackForm()
-    if form.validate_on_submit():
-        if utils.add_feedback(entry_id, form.body.data):
-            flash("投稿しました")
-        else:
-            flash("該当IDがありません")
-        return redirect(url_for("seminario.index"))
+    seminars = utils.get_kouza_seminars()
+    # Sort by lesson_date (start date), newest first
+    seminars.sort(key=lambda e: e.get("lesson_date") or "", reverse=True)
+    return render_template("seminario/seminario_confirm_list.html", seminars=seminars, user=user)
+
+
+@bp.route("/feedback_submission")
+def feedback_submission_page():
+    user = session.get("user")
+    # Fetches seminars and marks if user has submitted feedback for each
+    seminars_for_feedback = utils.get_seminars_for_feedback_page(user["username"])
+    # Sort by feedback_deadline, newest first
+    seminars_for_feedback.sort(key=lambda e: e.get("feedback_deadline") or "", reverse=True)
     return render_template(
-        "seminario_feedback_form.html", form=form, user=user, entry_id=entry_id
+        "seminario/seminario_feedback_submission.html",
+        seminars_for_feedback=seminars_for_feedback,
+        user=user,  # Pass user object for current_user.username in template
     )
 
+
+@bp.route("/submit_feedback/<int:entry_id>", methods=["POST"])
+def submit_feedback_for_seminar(entry_id: int):
+    user = session.get("user")
+    body = request.form.get("body", "").strip()
+
+    seminar = utils.get_seminar_by_id(entry_id)
+    if not seminar:
+        flash("指定されたセミナーが見つかりません。", "danger")
+        return redirect(url_for(".feedback_submission_page"))
+
+    # Check if seminar is a 'kouza' type, as feedback is for 'kouza'
+    if seminar.get("calendar_event_type") != "kouza":
+        flash("この種類のセミナーには感想を投稿できません。", "warning")
+        return redirect(url_for(".feedback_submission_page"))
+        
+    # Check if seminar is active
+    if seminar.get("status") != "active":
+        flash("このセミナーは現在アクティブではないため、感想を投稿できません。", "warning")
+        return redirect(url_for(".feedback_submission_page"))
+
+    # Check if feedback deadline has passed
+    today = date.today()
+    feedback_deadline_str = seminar.get("feedback_deadline")
+    if feedback_deadline_str:
+        try:
+            feedback_deadline_date = date.fromisoformat(feedback_deadline_str)
+            if today > feedback_deadline_date:
+                flash("このセミナーの感想投稿期限は過ぎています。", "warning")
+                return redirect(url_for(".feedback_submission_page"))
+        except ValueError:
+            flash("セミナーの締切日フォーマットが無効です。", "danger") # Should not happen with good data
+            return redirect(url_for(".feedback_submission_page"))
+            
+    if len(body) < 300:
+        flash("感想は300文字以上で入力してください。もう少し詳しく教えていただけますか？", "warning")
+        return redirect(url_for(".feedback_submission_page"))
+    
+    # Check if user has already submitted feedback (server-side check)
+    if user["username"] in seminar.get("feedback_submissions", {}):
+        flash("既にこのセミナーに関する感想を投稿済みです。", "info")
+        return redirect(url_for(".feedback_submission_page"))
+
+    if utils.add_feedback(entry_id, user["username"], body):
+        flash("感想を投稿しました。ありがとうございます！", "success")
+    else:
+        # This typically means the seminar ID was not found in utils.add_feedback,
+        # but we already checked for seminar existence. Could be a save error.
+        flash("感想の投稿中にエラーが発生しました。", "danger")
+    return redirect(url_for(".feedback_submission_page"))
+
+
+@bp.route("/completed")
+def completed_list():
+    user = session.get("user")
+    completed_seminars = utils.get_completed_seminars()
+    # Sort by seminar_end_date, newest first
+    completed_seminars.sort(key=lambda e: e.get("seminar_end_date") or "", reverse=True)
+    return render_template(
+        "seminario/seminario_completed_list.html",
+        completed_seminars=completed_seminars,
+        user=user,
+    )
+
+
+@bp.route("/complete_seminar/<int:entry_id>", methods=["POST"])
+def mark_seminar_completed(entry_id: int):
+    user = session.get("user")
+    if user.get("role") != "admin":
+        flash("管理者権限が必要です。", "danger")
+        return redirect(url_for(".index"))
+
+    seminar = utils.get_seminar_by_id(entry_id)
+    if not seminar:
+        flash("指定されたセミナーが見つかりません。", "danger")
+        # confirm_list is a good place for admins to come from/return to for this action
+        return redirect(url_for(".confirm_list"))
+
+    if seminar.get("status") == "completed":
+        flash(f"セミナー「{seminar.get('title', '')}」は既に完了としてマークされています。", "info")
+    elif utils.complete_seminar(entry_id):
+        flash(f"セミナー「{seminar.get('title', '')}」を完了にしました。", "success")
+    else:
+        flash("セミナーの完了処理中にエラーが発生しました。", "danger")
+    
+    return redirect(url_for(".confirm_list"))

--- a/app/Seminario/tasks.py
+++ b/app/Seminario/tasks.py
@@ -1,72 +1,119 @@
 """Background tasks for Seminario blueprint."""
 
-from datetime import date, timedelta
-from typing import List, Dict, Optional
+from datetime import date, timedelta, datetime # Added datetime for timestamping
+from typing import List, Dict, Any, Optional # Added Any
 
 try:  # pragma: no cover - optional dependency
     from apscheduler.schedulers.background import BackgroundScheduler
-except Exception:  # pragma: no cover - optional dependency
-    BackgroundScheduler = None  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    BackgroundScheduler = None
 
 import config
 from app.utils import send_email
 from . import utils
 
 
-scheduler = BackgroundScheduler() if BackgroundScheduler else None  # type: ignore
+scheduler = BackgroundScheduler() if BackgroundScheduler else None
 
 
-def notify_pending_feedback(
-    since: date, today: Optional[date] = None
-) -> List[Dict[str, str]]:
-    """Send reminder emails for lessons lacking feedback.
-
-    Parameters
-    ----------
-    since : date
-        Notify only entries whose lesson date is on or after this date.
-    today : Optional[date]
-        Date used to determine which lessons are considered past. Defaults to
-        ``date.today()``.
-
-    Returns
-    -------
-    List[Dict[str, str]]
-        Entries for which a notification was sent.
+def notify_pending_feedback() -> List[Dict[str, Any]]:
     """
+    Sends reminder emails for seminars lacking feedback.
+    - Daily reminders for users if feedback is due (after seminar end, before deadline).
+    - Overdue notifications for users if feedback is past deadline.
+    - Alerts admins if a user's feedback is overdue and admin hasn't been notified for that user/seminar pair.
+    Returns a list of notification records.
+    """
+    today = date.today()
+    # utils.pending_feedback returns active 'kouza' seminars where seminar_end_date < today
+    relevant_seminars = utils.pending_feedback(today)
+    
+    admin_users = utils.get_admin_users()  # List of admin user dicts with emails
+    notified_actions: List[Dict[str, Any]] = []
 
-    today = today or date.today()
-    pending = utils.pending_feedback(today)
-    notified: List[Dict[str, str]] = []
+    for seminar in relevant_seminars:
+        seminar_id = seminar.get("id")
+        seminar_title = seminar.get("title", "N/A")
+        feedback_deadline_str = seminar.get("feedback_deadline")
 
-    for entry in pending:
-        d_str = entry.get("lesson_date")
-        try:
-            d = date.fromisoformat(d_str) if d_str else None
-        except ValueError:
-            d = None
-        if not d or d < since:
+        if not seminar_id or not feedback_deadline_str:
+            # Log error: Missing critical seminar information
             continue
-        username = entry.get("author")
-        email = config.USERS.get(username, {}).get("email")
-        if email:
-            title = entry.get("title", "")
-            send_email("Feedback reminder", f"Please submit feedback for '{title}'", email)
-            notified.append(entry)
 
-    return notified
+        try:
+            # seminar_end_date_obj = date.fromisoformat(seminar.get("seminar_end_date")) # Provided by pending_feedback
+            feedback_deadline_obj = date.fromisoformat(feedback_deadline_str)
+        except ValueError:
+            # Log error: Invalid date format in seminar data
+            continue
+
+        for username_key, user_config_data in config.USERS.items():
+            if user_config_data.get('role') != 'admin' and user_config_data.get('email'):
+                user_email = user_config_data['email']
+                
+                submitted = username_key in seminar.get("feedback_submissions", {})
+
+                if not submitted:
+                    current_time_iso = datetime.now().isoformat()
+                    common_notification_data = {
+                        'user': username_key,
+                        'seminar_id': seminar_id,
+                        'seminar_title': seminar_title,
+                        'timestamp': current_time_iso
+                    }
+
+                    # Daily Reminder (seminar ended, feedback not submitted, deadline not passed)
+                    if today <= feedback_deadline_obj:
+                        send_email(
+                            "Seminar Feedback Reminder",
+                            f"Please submit feedback for '{seminar_title}'. Deadline: {feedback_deadline_str}",
+                            user_email
+                        )
+                        notified_actions.append({**common_notification_data, 'status': 'notified_due'})
+                    
+                    # Overdue Notification (deadline passed, feedback not submitted)
+                    else: # today > feedback_deadline_obj
+                        send_email(
+                            "OVERDUE: Seminar Feedback Required",
+                            f"Your feedback for '{seminar_title}' is overdue. Please submit it as soon as possible. Original deadline was {feedback_deadline_str}.",
+                            user_email
+                        )
+                        notified_actions.append({**common_notification_data, 'status': 'notified_overdue_user'})
+
+                        # Admin Notification Logic for this overdue, un-submitted feedback
+                        overdue_admin_notified_list = seminar.get("overdue_admin_notified_users", [])
+                        if username_key not in overdue_admin_notified_list:
+                            for admin_user_details in admin_users:
+                                admin_email = admin_user_details.get("email")
+                                if admin_email: # Should always be true due to get_admin_users logic
+                                    send_email(
+                                        "User Feedback Overdue Alert",
+                                        f"User '{username_key}' has not submitted feedback for seminar '{seminar_title}' (ID: {seminar_id}) which was due on {feedback_deadline_str}.",
+                                        admin_email
+                                    )
+                            
+                            if utils.add_user_to_admin_notified_list(seminar_id, username_key):
+                                notified_actions.append({
+                                    **common_notification_data,
+                                    'status': 'notified_overdue_admin',
+                                    'admin_notified_count': len(admin_users)
+                                })
+                            # else: Log failure to add user to notified list if necessary
+                            
+    return notified_actions
 
 
 def start_scheduler() -> None:
-    """Start APScheduler job to send daily feedback reminders."""
-
-    if scheduler is None:
+    """Start APScheduler job to send daily feedback reminders.
+    The job runs daily at 9 AM.
+    """
+    if scheduler is None:  # pragma: no cover
         return
 
-    if not scheduler.get_jobs():
+    if not scheduler.get_jobs(): # Ensure only one job is scheduled
         scheduler.add_job(
-            lambda: notify_pending_feedback(date.today() - timedelta(days=7)),
+            notify_pending_feedback,  # No lambda, no arguments
             "cron",
-            hour=9,
+            hour=9,  # Runs daily at 9 AM
         )
-        scheduler.start()
+        scheduler.start() # pragma: no cover

--- a/app/Seminario/templates/seminario/seminario_completed_list.html
+++ b/app/Seminario/templates/seminario/seminario_completed_list.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>終了したSeminarioページ</h2>
+
+    {% if completed_seminars %}
+    <table class="table table-striped table-hover">
+        <thead class="thead-light">
+            <tr>
+                <th scope="col">タイトル</th>
+                <th scope="col">開始日</th>
+                <th scope="col">終了日</th>
+                <!-- For future extension, could add:
+                <th scope="col">完了日</th>
+                <th scope="col">フィードバック数</th>
+                -->
+            </tr>
+        </thead>
+        <tbody>
+            {% for seminar in completed_seminars %}
+            <tr>
+                <td>{{ seminar.title }}</td>
+                <td>{{ seminar.lesson_date }}</td>
+                <td>{{ seminar.seminar_end_date }}</td>
+                <!-- For future extension:
+                <td>{{ seminar.completion_date_display or "N/A" }}</td>
+                <td>{{ seminar.feedback_submissions | length if seminar.feedback_submissions else 0 }}</td>
+                -->
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <div class="alert alert-info" role="alert">
+        完了したセミナーはありません。
+    </div>
+    {% endif %}
+
+    <p class="mt-3">
+        <a href="{{ url_for('seminario.seminario_list') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
+    </p>
+</div>
+{% endblock %}

--- a/app/Seminario/templates/seminario/seminario_confirm_list.html
+++ b/app/Seminario/templates/seminario/seminario_confirm_list.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Seminarioを確認ページ</h2>
+
+    {% if seminars %}
+    <table class="table table-striped table-hover">
+        <thead class="thead-light">
+            <tr>
+                <th scope="col">タイトル</th>
+                <th scope="col">開始日</th>
+                <th scope="col">終了日</th>
+                <th scope="col">フィードバック締切</th>
+                <!-- Optional: Admin actions can be added here -->
+                <!-- <th scope="col">操作</th> -->
+            </tr>
+        </thead>
+        <tbody>
+            {% for seminar in seminars %}
+            <tr>
+                <td>{{ seminar.title }}</td>
+                <td>{{ seminar.lesson_date }}</td>
+                <td>{{ seminar.seminar_end_date }}</td>
+                <td>{{ seminar.feedback_deadline }}</td>
+                <!-- Optional: Admin actions -->
+                <!--
+                <td>
+                    {% if is_admin %} {# Assuming a context variable 'is_admin' #}
+                        <a href="{{ url_for('seminario.complete_seminar_view', entry_id=seminar.id) }}" class="btn btn-sm btn-success">完了</a>
+                    {% endif %}
+                </td>
+                -->
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <div class="alert alert-info" role="alert">
+        該当する講座はありません。
+    </div>
+    {% endif %}
+
+    <p class="mt-3">
+        <a href="{{ url_for('seminario.seminario_list') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
+    </p>
+</div>
+{% endblock %}

--- a/app/Seminario/templates/seminario/seminario_feedback_submission.html
+++ b/app/Seminario/templates/seminario/seminario_feedback_submission.html
@@ -1,0 +1,85 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Seminario感想投稿ページ</h2>
+
+    {% if not seminars_for_feedback %}
+    <div class="alert alert-info" role="alert">
+        現在、感想を投稿できる講座はありません。
+    </div>
+    <p><a href="{{ url_for('seminario.seminario_list') }}" class="btn btn-secondary">Seminario一覧に戻る</a></p>
+    {% else %}
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs" id="seminarTabs" role="tablist">
+        {% for seminar in seminars_for_feedback %}
+        <li class="nav-item" role="presentation">
+            <button class="nav-link {% if loop.first %}active{% endif %}" id="tab-{{ seminar.id }}" data-bs-toggle="tab" data-bs-target="#content-{{ seminar.id }}" type="button" role="tab" aria-controls="content-{{ seminar.id }}" aria-selected="{{ 'true' if loop.first else 'false' }}">
+                {{ seminar.title }}
+            </button>
+        </li>
+        {% endfor %}
+    </ul>
+
+    <!-- Tab panes -->
+    <div class="tab-content" id="seminarTabsContent">
+        {% for seminar in seminars_for_feedback %}
+        <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="content-{{ seminar.id }}" role="tabpanel" aria-labelledby="tab-{{ seminar.id }}">
+            <div class="p-3 border border-top-0">
+                <h4>{{ seminar.title }}</h4>
+                <p><strong>終了日:</strong> {{ seminar.seminar_end_date }}</p>
+                <p><strong>フィードバック締切:</strong> {{ seminar.feedback_deadline }}</p>
+
+                {% if seminar.has_submitted_feedback %}
+                <div class="alert alert-info" role="alert">
+                    この講座に関する感想は投稿済みです。
+                </div>
+                {% if seminar.feedback_submissions and current_user and current_user.username in seminar.feedback_submissions %}
+                <div>
+                    <p><strong>あなたの投稿内容:</strong></p>
+                    <p style="white-space: pre-wrap;">{{ seminar.feedback_submissions[current_user.username].text }}</p>
+                </div>
+                {% elif seminar.submitted_feedback_text %} {# Fallback if specific user feedback text is pre-processed #}
+                <div>
+                    <p><strong>あなたの投稿内容:</strong></p>
+                    <p style="white-space: pre-wrap;">{{ seminar.submitted_feedback_text }}</p>
+                </div>
+                {% endif %}
+                {% else %}
+                {# Assuming form.csrf_token is not needed as no FlaskForm is explicitly passed for this page in the prompt #}
+                {# The backend route url_for('seminario.submit_feedback_for_seminar') should handle CSRF protection #}
+                <form method="POST" action="{{ url_for('seminario.submit_feedback_for_seminar', entry_id=seminar.id) }}">
+                    <div class="mb-3">
+                        <label for="body-{{ seminar.id }}" class="form-label">感想 (300文字以上):</label>
+                        <textarea class="form-control" id="body-{{ seminar.id }}" name="body" rows="8" required minlength="300"></textarea>
+                        <small class="form-text text-muted">
+                            感想は具体的に、300文字以上でご記入ください。
+                        </small>
+                    </div>
+                    <button type="submit" class="btn btn-primary">感想を送信</button>
+                </form>
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    <p class="mt-4">
+        <a href="{{ url_for('seminario.seminario_list') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
+    </p>
+    {% endif %}
+</div>
+
+<script>
+// Optional: Ensure Bootstrap tabs are correctly initialized if not using data-bs-toggle for everything
+// var triggerTabList = [].slice.call(document.querySelectorAll('#seminarTabs button'))
+// triggerTabList.forEach(function (triggerEl) {
+//   var tabTrigger = new bootstrap.Tab(triggerEl)
+//   triggerEl.addEventListener('click', function (event) {
+//     event.preventDefault()
+//     tabTrigger.show()
+//   })
+// })
+</script>
+
+{% endblock %}

--- a/app/Seminario/templates/seminario/seminario_list.html
+++ b/app/Seminario/templates/seminario/seminario_list.html
@@ -1,19 +1,43 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1>Seminario</h1>
-<ul>
-{% for e in entries %}
-    <li>[{{ e.id }}] {{ e.lesson_date }} {{ e.author }} {{ e.title }}
-        {% if e.feedback %}
-            - {{ e.feedback }}
-        {% else %}
-            <a href="{{ url_for('seminario.feedback', entry_id=e.id) }}">感想を書く</a>
-        {% endif %}
-    </li>
-{% endfor %}
-</ul>
-<p><a href="{{ url_for('seminario.schedule') }}">予定を登録</a></p>
-<p><a href="{{ url_for('index') }}">戻る</a></p>
+<div class="container mt-4">
+    <h1>Seminario一覧</h1> {# Changed heading slightly as per prompt's mention #}
+
+    <p class="mt-3 mb-3">
+      <a href="{{ url_for('seminario.confirm_list') }}" class="btn btn-info btn-sm">Seminarioを確認</a>
+      <a href="{{ url_for('seminario.feedback_submission_page') }}" class="btn btn-info btn-sm">Seminarioの感想を投稿</a>
+      <a href="{{ url_for('seminario.completed_list') }}" class="btn btn-info btn-sm">終了したSeminarioを確認</a>
+    </p>
+
+    <h2>現在アクティブなSeminario</h2>
+    {% if entries %}
+    <ul class="list-group">
+    {% for seminar in entries %} {# Renamed 'e' to 'seminar' for clarity #}
+        <li class="list-group-item">
+            <strong>タイトル:</strong> {{ seminar.title }}<br>
+            <strong>ID:</strong> {{ seminar.id }}<br>
+            <strong>講師:</strong> {{ seminar.author }}<br>
+            <strong>開始日:</strong> {{ seminar.lesson_date }}<br>
+            <strong>終了日:</strong> {{ seminar.seminar_end_date }}<br>
+            <strong>種類:</strong> {{ seminar.calendar_event_type }}
+            {# The old feedback link/text is removed as per new feedback system #}
+            {# If a direct link to submit feedback for THIS specific seminar is desired,
+               it would be a link to feedback_submission_page possibly with a query param
+               or an anchor to the specific tab, but the current structure is a general link. #}
+        </li>
+    {% endfor %}
+    </ul>
+    {% else %}
+    <div class="alert alert-info" role="alert">
+        現在アクティブなセミナーはありません。
+    </div>
+    {% endif %}
+
+    <hr>
+
+    <p><a href="{{ url_for('seminario.schedule') }}" class="btn btn-primary">新しいSeminarioを登録</a></p> {# Styled button #}
+    <p><a href="{{ url_for('index') }}" class="btn btn-secondary">メインページに戻る</a></p> {# Styled button #}
+</div>
 {% endblock %}
 

--- a/app/Seminario/utils.py
+++ b/app/Seminario/utils.py
@@ -1,9 +1,9 @@
 """Utility functions for Seminario schedules and feedback."""
 
 import json
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 
 import config
 
@@ -11,56 +11,173 @@ import config
 SEMINARIO_PATH = Path(getattr(config, "SEMINARIO_FILE", "seminario.json"))
 
 
-def load_entries() -> List[Dict[str, str]]:
+def load_entries() -> List[Dict[str, Any]]:
     if SEMINARIO_PATH.exists():
         with open(SEMINARIO_PATH, "r", encoding="utf-8") as f:
             return json.load(f)
     return []
 
 
-def save_entries(entries: List[Dict[str, str]]) -> None:
+def save_entries(entries: List[Dict[str, Any]]) -> None:
     with open(SEMINARIO_PATH, "w", encoding="utf-8") as f:
         json.dump(entries, f, ensure_ascii=False, indent=2)
 
 
-def add_schedule(author: str, lesson_date: date, title: str) -> None:
+def add_schedule(
+    author: str,
+    lesson_date: date,
+    title: str,
+    calendar_event_type: str,
+    seminar_end_date: date,
+) -> None:
     entries = load_entries()
-    next_id = max((e.get("id", 0) for e in entries), default=0) + 1
+    next_id = max((int(e.get("id", 0)) for e in entries), default=0) + 1
     entries.append(
         {
             "id": next_id,
             "author": author,
-            "lesson_date": lesson_date.isoformat(),
+            "lesson_date": lesson_date.isoformat(),  # Seminar start date
             "title": title,
-            "feedback": "",
-            "timestamp": datetime.now().isoformat(timespec="seconds"),
+            "calendar_event_type": calendar_event_type,
+            "seminar_end_date": seminar_end_date.isoformat(),
+            "feedback_deadline": (seminar_end_date + timedelta(days=7)).isoformat(),
+            "status": "active",
+            "feedback_submissions": {},
+            "overdue_admin_notified_users": [], # New field
+            "timestamp": datetime.now().isoformat(timespec="seconds"),  # Entry creation timestamp
         }
     )
     save_entries(entries)
 
 
-def add_feedback(entry_id: int, body: str) -> bool:
+def add_feedback(entry_id: int, username: str, body: str) -> bool:
     entries = load_entries()
     for e in entries:
         if e.get("id") == entry_id:
-            e["feedback"] = body
-            e["feedback_timestamp"] = datetime.now().isoformat(timespec="seconds")
+            # Ensure feedback_submissions field exists
+            if "feedback_submissions" not in e:
+                e["feedback_submissions"] = {}
+            e["feedback_submissions"][username] = {
+                "text": body,
+                "timestamp": datetime.now().isoformat(timespec="seconds"),
+            }
             save_entries(entries)
             return True
     return False
 
 
-def pending_feedback(today: Optional[date] = None) -> List[Dict[str, str]]:
+def get_seminar_by_id(entry_id: int) -> Optional[Dict[str, Any]]:
+    entries = load_entries()
+    for e in entries:
+        if e.get("id") == entry_id:
+            return e
+    return None
+
+
+def get_kouza_seminars() -> List[Dict[str, Any]]:
+    entries = load_entries()
+    return [
+        e
+        for e in entries
+        if e.get("calendar_event_type") == "kouza" and e.get("status") == "active"
+    ]
+
+
+def get_active_seminars() -> List[Dict[str, Any]]:
+    entries = load_entries()
+    return [e for e in entries if e.get("status") != "completed"]
+
+
+def get_completed_seminars() -> List[Dict[str, Any]]:
+    entries = load_entries()
+    return [e for e in entries if e.get("status") == "completed"]
+
+
+def complete_seminar(entry_id: int) -> bool:
+    entries = load_entries()
+    found = False
+    for e in entries:
+        if e.get("id") == entry_id:
+            e["status"] = "completed"
+            found = True
+            break
+    if found:
+        save_entries(entries)
+        return True
+    return False
+
+
+def get_seminars_for_feedback_page(username: str) -> List[Dict[str, Any]]:
+    entries = load_entries()
+    kouza_seminars = [
+        e
+        for e in entries
+        if e.get("calendar_event_type") == "kouza" and e.get("status") == "active"
+    ]
+    for seminar in kouza_seminars:
+        seminar["has_submitted_feedback"] = username in seminar.get(
+            "feedback_submissions", {}
+        )
+    return kouza_seminars
+
+
+def pending_feedback(today: Optional[date] = None) -> List[Dict[str, Any]]:
     today = today or date.today()
     entries = load_entries()
-    results: List[Dict[str, str]] = []
+    results: List[Dict[str, Any]] = []
     for e in entries:
-        d_str = e.get("lesson_date")
+        seminar_end_date_str = e.get("seminar_end_date")
         try:
-            d = date.fromisoformat(d_str) if d_str else None
+            seminar_end_date = (
+                date.fromisoformat(seminar_end_date_str) if seminar_end_date_str else None
+            )
         except ValueError:
-            d = None
-        if d and d < today and not e.get("feedback"):
+            seminar_end_date = None
+
+        if (
+            e.get("calendar_event_type") == "kouza"
+            and e.get("status") == "active"
+            and seminar_end_date
+            and seminar_end_date < today
+        ):
             results.append(e)
     return results
+
+
+def add_user_to_admin_notified_list(entry_id: int, username: str) -> bool:
+    """Adds a username to the list of admins notified about overdue feedback for a seminar."""
+    entries = load_entries()
+    seminar_found = False
+    user_added = False
+    for seminar in entries:
+        if seminar.get("id") == entry_id:
+            seminar_found = True
+            # Ensure the list exists, using setdefault to initialize if not present
+            notified_list = seminar.setdefault("overdue_admin_notified_users", [])
+            if username not in notified_list:
+                notified_list.append(username)
+                user_added = True
+            break  # Exit loop once seminar is found
+
+    if seminar_found and user_added:
+        save_entries(entries)
+        return True
+    return False
+
+
+def get_admin_users() -> List[Dict[str, Any]]:
+    """Retrieves a list of admin users with email addresses from config."""
+    admin_users: List[Dict[str, Any]] = []
+    if hasattr(config, "USERS") and isinstance(config.USERS, dict):
+        for user_name, user_data in config.USERS.items():
+            if isinstance(user_data, dict) and \
+               user_data.get("role") == "admin" and \
+               user_data.get("email"): # Ensure email exists and is not empty
+                # Add the username to the user_data if it's not already there
+                # or if you want to ensure it's present under a specific key.
+                # For now, just returning the user_data dict.
+                # user_data_with_username = user_data.copy()
+                # user_data_with_username['username'] = user_name
+                admin_users.append(user_data) # user_data already contains all info
+    return admin_users
 

--- a/app/calendario/forms.py
+++ b/app/calendario/forms.py
@@ -26,6 +26,8 @@ class EventForm(FlaskForm):
             ("shift", "シフト"),
             ("lesson", "レッスン"),
             ("hug", "ハグの日"),
+            ('kouza', '講座'),
+            ('shucchou', '出張'),
             ("other", "その他"),
         ],
         validators=[DataRequired()],


### PR DESCRIPTION
This commit introduces several new features and enhancements to the Seminario and Calendario modules based on your issue requirements.

Calendario:
- I added '講座' (Lecture/Course) and '出張' (Business Trip) as new event categories in `app/calendario/forms.py`.

Seminario:
- I updated the `seminario.json` data structure (`app/Seminario/utils.py`):
    - I added `calendar_event_type`, `seminar_end_date`, `feedback_deadline`, `status`, `feedback_submissions`, and `overdue_admin_notified_users`.
- New Pages and Templates (`app/Seminario/templates/seminario/`):
    - `seminario_confirm_list.html`: This displays active '講座' seminars.
    - `seminario_feedback_submission.html`: This allows users to submit feedback (min 300 chars) via tabs for active '講座' seminars.
    - `seminario_completed_list.html`: This displays completed seminars.
- Routes (`app/Seminario/routes.py`):
    - I added routes for the new pages.
    - I implemented logic for seminar display, feedback submission (with validation), and admin-only seminar completion.
    - I updated the main seminario page (`seminario_list.html`) with links to new sections and improved layout.
- Forms (`app/Seminario/forms.py`):
    - I modified `LessonScheduleForm` to include `seminar_end_date` and `calendar_event_type`.
- Notifications (`app/Seminario/tasks.py`):
    - I implemented a multi-stage notification system: - Daily reminders for users post-seminar, pre-deadline. - Daily urgent reminders for users post-deadline. - One-time admin notification per user/seminar for overdue feedback.
    - I updated the APScheduler job to use the new notification logic.