### PR TITLE
feat: Implement Seminario/Calendario features and fix template paths

### DIFF
--- a/app/Seminario/routes.py
+++ b/app/Seminario/routes.py
@@ -22,7 +22,7 @@ def index():
     entries = utils.get_active_seminars()
     # Sort by lesson_date (start date), newest first. Ensure robust sorting.
     entries.sort(key=lambda e: e.get("lesson_date") or "", reverse=True)
-    return render_template("seminario/seminario_list.html", entries=entries, user=user)
+    return render_template("seminario_list.html", entries=entries, user=user)
 
 
 @bp.route("/schedule", methods=["GET", "POST"])
@@ -43,7 +43,7 @@ def schedule():
         )
         flash("新しいセミナーを登録しました。", "success")
         return redirect(url_for(".index"))
-    return render_template("seminario/seminario_schedule_form.html", form=form, user=user)
+    return render_template("seminario_schedule_form.html", form=form, user=user)
 
 
 # The old feedback(entry_id) route has been removed.
@@ -56,7 +56,7 @@ def confirm_list():
     seminars = utils.get_kouza_seminars()
     # Sort by lesson_date (start date), newest first
     seminars.sort(key=lambda e: e.get("lesson_date") or "", reverse=True)
-    return render_template("seminario/seminario_confirm_list.html", seminars=seminars, user=user)
+    return render_template("seminario_confirm_list.html", seminars=seminars, user=user)
 
 
 @bp.route("/feedback_submission")
@@ -67,7 +67,7 @@ def feedback_submission_page():
     # Sort by feedback_deadline, newest first
     seminars_for_feedback.sort(key=lambda e: e.get("feedback_deadline") or "", reverse=True)
     return render_template(
-        "seminario/seminario_feedback_submission.html",
+        "seminario_feedback_submission.html",
         seminars_for_feedback=seminars_for_feedback,
         user=user,  # Pass user object for current_user.username in template
     )
@@ -131,7 +131,7 @@ def completed_list():
     # Sort by seminar_end_date, newest first
     completed_seminars.sort(key=lambda e: e.get("seminar_end_date") or "", reverse=True)
     return render_template(
-        "seminario/seminario_completed_list.html",
+        "seminario_completed_list.html",
         completed_seminars=completed_seminars,
         user=user,
     )


### PR DESCRIPTION
This commit introduces several new features and enhancements to the Seminario and Calendario modules and fixes a template path issue in Seminario routes.

Calendario:
- Added '講座' (Lecture/Course) and '出張' (Business Trip) as new event categories in `app/calendario/forms.py`.

Seminario:
- Routes (`app/Seminario/routes.py`):
    - Corrected `render_template()` calls by removing the redundant "seminario/" prefix, resolving a TemplateNotFound error.
    - Added routes for new pages: seminar confirmation, feedback submission, and completed seminars list.
    - Implemented logic for seminar display, feedback submission (with validation), and admin-only seminar completion.
    - Updated main seminario page (`seminario_list.html`) with links to new sections and improved layout.
- Data Structure (`app/Seminario/utils.py`):
    - Updated `seminario.json` data structure to include `calendar_event_type`, `seminar_end_date`, `feedback_deadline`, `status`, `feedback_submissions`, and `overdue_admin_notified_users`.
- New Pages and Templates (`app/Seminario/templates/seminario/`):
    - `seminario_confirm_list.html`: Displays active '講座' seminars.
    - `seminario_feedback_submission.html`: Allows you to submit feedback (min 300 chars) via tabs for active '講座' seminars.
    - `seminario_completed_list.html`: Displays completed seminars.
- Forms (`app/Seminario/forms.py`):
    - Modified `LessonScheduleForm` to include `seminar_end_date` and `calendar_event_type`.
- Notifications (`app/Seminario/tasks.py`):
    - Implemented multi-stage notification system: - Daily reminders for you post-seminar, pre-deadline. - Daily urgent reminders for you post-deadline. - One-time admin notification per user/seminar for overdue feedback.
    - Updated APScheduler job to use the new notification logic.