### PR TITLE
fix: Correct url_for calls in Seminario templates

### DIFF
--- a/app/Seminario/templates/seminario/seminario_completed_list.html
+++ b/app/Seminario/templates/seminario/seminario_completed_list.html
@@ -38,7 +38,7 @@
     {% endif %}
 
     <p class="mt-3">
-        <a href="{{ url_for('seminario.seminario_list') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
+        <a href="{{ url_for('seminario.index') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
     </p>
 </div>
 {% endblock %}

--- a/app/Seminario/templates/seminario/seminario_confirm_list.html
+++ b/app/Seminario/templates/seminario/seminario_confirm_list.html
@@ -42,7 +42,7 @@
     {% endif %}
 
     <p class="mt-3">
-        <a href="{{ url_for('seminario.seminario_list') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
+        <a href="{{ url_for('seminario.index') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
     </p>
 </div>
 {% endblock %}

--- a/app/Seminario/templates/seminario/seminario_feedback_submission.html
+++ b/app/Seminario/templates/seminario/seminario_feedback_submission.html
@@ -8,7 +8,7 @@
     <div class="alert alert-info" role="alert">
         現在、感想を投稿できる講座はありません。
     </div>
-    <p><a href="{{ url_for('seminario.seminario_list') }}" class="btn btn-secondary">Seminario一覧に戻る</a></p>
+    <p><a href="{{ url_for('seminario.index') }}" class="btn btn-secondary">Seminario一覧に戻る</a></p>
     {% else %}
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" id="seminarTabs" role="tablist">
@@ -65,7 +65,7 @@
     </div>
 
     <p class="mt-4">
-        <a href="{{ url_for('seminario.seminario_list') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
+        <a href="{{ url_for('seminario.index') }}" class="btn btn-secondary">Seminario一覧に戻る</a>
     </p>
     {% endif %}
 </div>


### PR DESCRIPTION
I corrected `url_for` calls in Seminario templates to point to 'seminario.index' instead of the non-existent 'seminario.seminario_list' endpoint. This resolves a werkzeug.routing.exceptions.BuildError that prevented access to newly added Seminario pages.

Affected templates:
- app/Seminario/templates/seminario/seminario_confirm_list.html
- app/Seminario/templates/seminario/seminario_feedback_submission.html
- app/Seminario/templates/seminario/seminario_completed_list.html