### PR TITLE
fix: Add macros.html to resolve TemplateNotFound error

### DIFF
--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -1,0 +1,11 @@
+{% macro format_datetime_field(timestamp_string) %}
+  {# This macro is a placeholder. Date formatting should ideally be done
+     in the Python view function before passing to the template,
+     or via a custom Jinja filter for parsing ISO strings.
+     For now, it will just display the raw string if not empty. #}
+  {% if timestamp_string %}
+    {{ timestamp_string }}
+  {% else %}
+    {# Handle empty or None timestamp_string #}
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
I created `app/templates/macros.html` with a placeholder `format_datetime_field` macro. This resolves the `TemplateNotFound` error you encountered when accessing Monsignore Kadai pages, which attempt to import this macro.

The macro currently displays the raw timestamp string. Further customization of date/time formatting can be handled in a subsequent update if you require it.