### PR TITLE
feat: Implement media copy to custom folder (reference style) for Decima

### DIFF
--- a/app/principessina/forms.py
+++ b/app/principessina/forms.py
@@ -1,12 +1,12 @@
 """Forms for Decima (formerly Principessina) blueprint."""
 
 from flask_wtf import FlaskForm
-from flask_wtf.file import FileAllowed # Re-added
-from wtforms import StringField, TextAreaField, SubmitField, FileField # Re-added FileField, StringField
-from wtforms.validators import DataRequired, Optional, Length # Re-added Optional, added Length
+from flask_wtf.file import FileAllowed
+from wtforms import StringField, TextAreaField, SubmitField, FileField, SelectField # Added SelectField
+from wtforms.validators import DataRequired, Optional, Length
 
-from app.validators import FileSize # Re-added
-from . import utils # Added for accessing constants
+from app.validators import FileSize
+from . import utils 
 
 
 class ReportForm(FlaskForm):
@@ -50,8 +50,16 @@ class CreateCustomFolderForm(FlaskForm):
         validators=[
             DataRequired(message="フォルダ名を入力してください。"), 
             Length(min=1, max=100, message="フォルダ名は1文字以上100文字以内で入力してください。")
-            # Consider adding a Regexp validator here for allowed characters in folder names
-            # e.g., Regexp(r'^[a-zA-Z0-9_-]+$', message="フォルダ名には英数字、アンダースコア、ハイフンのみ使用できます。")
         ]
     )
     submit = SubmitField("フォルダ作成")
+
+
+class CopyMediaToCustomFolderForm(FlaskForm):
+    """Form to copy (reference) a media item to a custom folder."""
+    target_custom_folder = SelectField(
+        "コピー先のカスタムフォルダ", 
+        choices=[], # To be populated dynamically in the route
+        validators=[DataRequired(message="コピー先のフォルダを選択してください。")]
+    )
+    submit_copy = SubmitField("このフォルダにコピー")

--- a/app/principessina/routes.py
+++ b/app/principessina/routes.py
@@ -15,14 +15,15 @@ from app.utils import save_uploaded_file
 from datetime import datetime, date
 
 from . import bp
-from .forms import ReportForm, VideoUploadForm, PhotoUploadForm, CreateCustomFolderForm # Added PhotoUploadForm
+from .forms import (
+    ReportForm, VideoUploadForm, PhotoUploadForm, 
+    CreateCustomFolderForm, CopyMediaToCustomFolderForm # Added CopyMediaToCustomFolderForm
+)
 from . import utils
 
-# Base directory for all Principessina uploads within static/uploads/
 PRINCIPESSINA_UPLOAD_BASE_DIR_REL_TO_STATIC_UPLOADS = "principessina"
-# Specific directories for media types relative to PRINCIPESSINA_UPLOAD_BASE_DIR
 VIDEO_DIR_REL_TO_PRINCIPESSINA_UPLOADS = "videos"
-PHOTO_DIR_REL_TO_PRINCIPESSINA_UPLOADS = "photos" # New constant for photos
+PHOTO_DIR_REL_TO_PRINCIPESSINA_UPLOADS = "photos"
 
 
 @bp.before_request
@@ -30,33 +31,27 @@ def require_login():
     if "user" not in session:
         return redirect(url_for("auth.login", next=request.url))
 
-# --- Helper Function ---
 def get_principessina_base_upload_path_abs():
-    """Returns absolute path to static/uploads/principessina"""
     return os.path.join(current_app.static_folder, "uploads", PRINCIPESSINA_UPLOAD_BASE_DIR_REL_TO_STATIC_UPLOADS)
 
-# --- Text Report Routes (Yura, Mangiato) ---
 @bp.route("/")
 def index():
     user = session.get("user")
     return render_template("principessina_feed.html", user=user)
 
+# --- Text Report Routes ---
 @bp.route('/yura', methods=['GET', 'POST'])
 def yura_report():
     user = session.get("user")
     form = ReportForm()
     if form.validate_on_submit():
         text = form.text_content.data
-        if len(text) < 200:
-            flash("短すぎるね、200文字以上になるようにもう少し集中したほうが良い", "warning")
+        if len(text) < 200: flash("短すぎるね、200文字以上になるようにもう少し集中したほうが良い", "warning")
         else:
             utils.add_report(author=user['username'], report_type="yura", text_content=text)
             flash("「今日のユラちゃん」を報告しました。", "success")
             return redirect(url_for('.yura_report'))
-    today_yura_reports = [
-        r for r in utils.get_active_reports(report_type="yura") 
-        if datetime.fromisoformat(r['timestamp']).date() == date.today()
-    ]
+    today_yura_reports = [r for r in utils.get_active_reports(report_type="yura") if datetime.fromisoformat(r['timestamp']).date() == date.today()]
     today_yura_reports.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
     return render_template("decima_yura_report.html", form=form, reports=today_yura_reports, user=user)
 
@@ -69,10 +64,7 @@ def mangiato_report():
         utils.add_report(author=user['username'], report_type="mangiato", text_content=text)
         flash("「食べたもの」を報告しました。", "success")
         return redirect(url_for('.mangiato_report'))
-    today_mangiato_reports = [
-        r for r in utils.get_active_reports(report_type="mangiato")
-        if datetime.fromisoformat(r['timestamp']).date() == date.today()
-    ]
+    today_mangiato_reports = [r for r in utils.get_active_reports(report_type="mangiato") if datetime.fromisoformat(r['timestamp']).date() == date.today()]
     today_mangiato_reports.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
     return render_template("decima_mangiato_report.html", form=form, reports=today_mangiato_reports, user=user)
 
@@ -80,79 +72,66 @@ def mangiato_report():
 def delete_report(report_id: int):
     user = session.get("user")
     if user.get("role") != "admin":
-        flash("権限がありません。", "danger")
-        return redirect(url_for(".index"))
+        flash("権限がありません。", "danger"); return redirect(url_for(".index"))
     all_reports = utils.load_posts() 
     found_report = next((r for r in all_reports if r.get("id") == report_id), None)
-    report_type_for_redirect = None
-    if found_report: report_type_for_redirect = found_report.get("report_type")
+    rt = found_report.get("report_type") if found_report else None
     if utils.delete_post(report_id): flash("報告を削除しました。", "success")
     else: flash("該当IDの報告が見つかりません。", "warning")
-    if report_type_for_redirect == "yura": return redirect(url_for(".yura_report"))
-    if report_type_for_redirect == "mangiato": return redirect(url_for(".mangiato_report"))
+    if rt == "yura": return redirect(url_for(".yura_report"))
+    if rt == "mangiato": return redirect(url_for(".mangiato_report"))
     return redirect(url_for(".index"))
 
-# --- Media Feature Routes (Video, Photo) ---
-
+# --- Media Feature Routes ---
 @bp.route('/video', methods=['GET', 'POST'])
 def video_page():
     user = session.get("user")
     video_form = VideoUploadForm()
     folder_form = CreateCustomFolderForm()
+    copy_form = CopyMediaToCustomFolderForm() # New form
     current_folder_name = request.args.get('current_folder')
     
-    # Absolute path to static/uploads/principessina/videos
     media_type_base_path_abs = os.path.join(get_principessina_base_upload_path_abs(), VIDEO_DIR_REL_TO_PRINCIPESSINA_UPLOADS)
     os.makedirs(media_type_base_path_abs, exist_ok=True)
 
+    all_custom_folders = utils.get_custom_folders(media_type_base_path_abs)
+    copy_form.target_custom_folder.choices = [(folder, folder) for folder in all_custom_folders]
+
     if request.method == 'POST':
         if request.form.get('form_type') == 'upload_video' and video_form.validate_on_submit():
-            file = video_form.video_file.data
-            title = video_form.title.data
+            file = video_form.video_file.data; title = video_form.title.data
             db_custom_folder_name = current_folder_name
-            
             if current_folder_name:
-                # Uploading to a specific custom folder
                 target_dir_for_upload_abs = os.path.join(media_type_base_path_abs, "custom", current_folder_name)
-                # server_path_prefix_for_db is like "principessina/videos/custom/myfolder"
                 server_path_prefix_for_db = os.path.join(PRINCIPESSINA_UPLOAD_BASE_DIR_REL_TO_STATIC_UPLOADS, VIDEO_DIR_REL_TO_PRINCIPESSINA_UPLOADS, "custom", current_folder_name)
             else:
-                # Uploading to year/month/week folder
-                now = datetime.now()
-                year, month, week = now.year, now.month, now.isocalendar()[1]
-                # year_week_path_part is 'videos/YYYY/MM/WW' (relative to 'static/uploads/principessina')
+                now = datetime.now(); year, month, week = now.year, now.month, now.isocalendar()[1]
                 year_week_path_part = utils.ensure_media_folder_structure(get_principessina_base_upload_path_abs(), "videos", year, month, week)
                 target_dir_for_upload_abs = os.path.join(get_principessina_base_upload_path_abs(), year_week_path_part)
-                # server_path_prefix_for_db is like "principessina/videos/YYYY/MM/WW"
                 server_path_prefix_for_db = os.path.join(PRINCIPESSINA_UPLOAD_BASE_DIR_REL_TO_STATIC_UPLOADS, year_week_path_part)
                 db_custom_folder_name = None
-
             os.makedirs(target_dir_for_upload_abs, exist_ok=True)
             try:
                 saved_filename = save_uploaded_file(file, target_dir_for_upload_abs, utils.ALLOWED_VIDEO_EXTS, utils.MAX_MEDIA_SIZE)
                 server_filepath_for_db = os.path.join(server_path_prefix_for_db, saved_filename)
-                utils.add_media_entry(
-                    uploader_username=user['username'], media_type="video",
-                    original_filename=file.filename, server_filepath=server_filepath_for_db,
-                    title=title, custom_folder_name=db_custom_folder_name)
+                utils.add_media_entry(user['username'], "video", file.filename, server_filepath_for_db, title, db_custom_folder_name)
                 flash("動画をアップロードしました。", "success")
             except ValueError as e: flash(str(e), "danger")
             return redirect(url_for('.video_page', current_folder=current_folder_name))
-
         elif request.form.get('form_type') == 'create_folder' and folder_form.validate_on_submit():
             new_folder_name = folder_form.folder_name.data
             success, message = utils.create_custom_media_folder(media_type_base_path_abs, new_folder_name)
             flash(message, "success" if success else "danger")
             return redirect(url_for('.video_page', current_folder=new_folder_name if success else current_folder_name))
 
-    custom_folders = utils.get_custom_folders(media_type_base_path_abs)
     media_entries = utils.get_media_entries(media_type="video", custom_folder_name=current_folder_name)
     media_entries.sort(key=lambda x: x.get("upload_timestamp", ""), reverse=True)
     current_folder_display_name = current_folder_name if current_folder_name else "年月フォルダ"
-
     return render_template("decima_video_page.html", 
-        video_form=video_form, folder_form=folder_form, video_entries=media_entries, 
-        custom_video_folders=custom_folders, current_folder_name=current_folder_name,
+        video_form=video_form, folder_form=folder_form, copy_form=copy_form, # Added copy_form
+        video_entries=media_entries, custom_video_folders=all_custom_folders, # Renamed for clarity
+        all_custom_video_folders=all_custom_folders, # Explicitly for template
+        current_folder_name=current_folder_name,
         current_folder_display_name=current_folder_display_name, user=user)
 
 @bp.route('/photo', methods=['GET', 'POST'])
@@ -160,62 +139,104 @@ def photo_page():
     user = session.get("user")
     photo_form = PhotoUploadForm()
     folder_form = CreateCustomFolderForm()
+    copy_form = CopyMediaToCustomFolderForm() # New form
     current_folder_name = request.args.get('current_folder')
 
-    # Absolute path to static/uploads/principessina/photos
     media_type_base_path_abs = os.path.join(get_principessina_base_upload_path_abs(), PHOTO_DIR_REL_TO_PRINCIPESSINA_UPLOADS)
     os.makedirs(media_type_base_path_abs, exist_ok=True) 
 
+    all_custom_folders = utils.get_custom_folders(media_type_base_path_abs)
+    copy_form.target_custom_folder.choices = [(folder, folder) for folder in all_custom_folders]
+
     if request.method == 'POST':
         if request.form.get('form_type') == 'upload_photo' and photo_form.validate_on_submit():
-            file = photo_form.photo_file.data
-            title = photo_form.title.data
+            file = photo_form.photo_file.data; title = photo_form.title.data
             db_custom_folder_name = current_folder_name
-
             if current_folder_name:
                 target_dir_for_upload_abs = os.path.join(media_type_base_path_abs, "custom", current_folder_name)
                 server_path_prefix_for_db = os.path.join(PRINCIPESSINA_UPLOAD_BASE_DIR_REL_TO_STATIC_UPLOADS, PHOTO_DIR_REL_TO_PRINCIPESSINA_UPLOADS, "custom", current_folder_name)
             else:
-                now = datetime.now()
-                year, month, week = now.year, now.month, now.isocalendar()[1]
-                # year_week_path_part is 'photos/YYYY/MM/WW' (relative to 'static/uploads/principessina')
+                now = datetime.now(); year, month, week = now.year, now.month, now.isocalendar()[1]
                 year_week_path_part = utils.ensure_media_folder_structure(get_principessina_base_upload_path_abs(), "photos", year, month, week)
                 target_dir_for_upload_abs = os.path.join(get_principessina_base_upload_path_abs(), year_week_path_part)
                 server_path_prefix_for_db = os.path.join(PRINCIPESSINA_UPLOAD_BASE_DIR_REL_TO_STATIC_UPLOADS, year_week_path_part)
                 db_custom_folder_name = None
-            
             os.makedirs(target_dir_for_upload_abs, exist_ok=True)
             try:
                 saved_filename = save_uploaded_file(file, target_dir_for_upload_abs, utils.ALLOWED_PHOTO_EXTS, utils.MAX_MEDIA_SIZE)
                 server_filepath_for_db = os.path.join(server_path_prefix_for_db, saved_filename)
-                utils.add_media_entry(
-                    uploader_username=user['username'], media_type="photo",
-                    original_filename=file.filename, server_filepath=server_filepath_for_db,
-                    title=title, custom_folder_name=db_custom_folder_name)
+                utils.add_media_entry(user['username'], "photo", file.filename, server_filepath_for_db, title, db_custom_folder_name)
                 flash("写真をアップロードしました。", "success")
             except ValueError as e: flash(str(e), "danger")
             return redirect(url_for('.photo_page', current_folder=current_folder_name))
-
         elif request.form.get('form_type') == 'create_folder' and folder_form.validate_on_submit():
             new_folder_name = folder_form.folder_name.data
             success, message = utils.create_custom_media_folder(media_type_base_path_abs, new_folder_name)
             flash(message, "success" if success else "danger")
             return redirect(url_for('.photo_page', current_folder=new_folder_name if success else current_folder_name))
 
-    custom_folders = utils.get_custom_folders(media_type_base_path_abs)
     media_entries = utils.get_media_entries(media_type="photo", custom_folder_name=current_folder_name)
     media_entries.sort(key=lambda x: x.get("upload_timestamp", ""), reverse=True)
     current_folder_display_name = current_folder_name if current_folder_name else "年月フォルダ"
-
     return render_template("decima_photo_page.html", 
-        photo_form=photo_form, folder_form=folder_form, photo_entries=media_entries, 
-        custom_photo_folders=custom_folders, current_folder_name=current_folder_name,
+        photo_form=photo_form, folder_form=folder_form, copy_form=copy_form, # Added copy_form
+        photo_entries=media_entries, custom_photo_folders=all_custom_folders, # Renamed for clarity
+        all_custom_photo_folders=all_custom_folders, # Explicitly for template
+        current_folder_name=current_folder_name,
         current_folder_display_name=current_folder_display_name, user=user)
 
 # --- Common Media Routes ---
+@bp.route('/media/<int:media_id>/copy_to_folder', methods=['POST'])
+def copy_media_to_folder(media_id: int):
+    user = session.get("user") # Ensure user is logged in
+    form = CopyMediaToCustomFolderForm(request.form) # Pass request.form
+    media_type = request.form.get('media_type') # "video" or "photo"
+    source_folder = request.form.get('source_folder') # To redirect back
+
+    # Determine base path for the media type to get custom folder choices
+    if media_type == "video":
+        media_type_base_path_abs = os.path.join(get_principessina_base_upload_path_abs(), VIDEO_DIR_REL_TO_PRINCIPESSINA_UPLOADS)
+    elif media_type == "photo":
+        media_type_base_path_abs = os.path.join(get_principessina_base_upload_path_abs(), PHOTO_DIR_REL_TO_PRINCIPESSINA_UPLOADS)
+    else:
+        flash("無効なメディアタイプです。", "danger"); return redirect(url_for(".index"))
+    
+    all_custom_folders = utils.get_custom_folders(media_type_base_path_abs)
+    form.target_custom_folder.choices = [(folder, folder) for folder in all_custom_folders]
+
+    if form.validate_on_submit():
+        target_folder = form.target_custom_folder.data
+        success = utils.add_media_reference_to_custom_folder(media_id, target_folder)
+        if success: flash(f"メディアをカスタムフォルダ「{target_folder}」にコピー（参照追加）しました。", "success")
+        else: flash("メディアのコピー（参照追加）に失敗しました。既に参照されているか、プライマリフォルダ、またはIDが見つかりません。", "warning")
+    else:
+        for field, errors in form.errors.items():
+            flash(f"エラー ({getattr(form, field).label.text}): {', '.join(errors)}", "danger")
+
+    if media_type == "video": return redirect(url_for('.video_page', current_folder=source_folder if source_folder else None))
+    if media_type == "photo": return redirect(url_for('.photo_page', current_folder=source_folder if source_folder else None))
+    return redirect(url_for(".index"))
+
+@bp.route('/media/<int:media_id>/remove_reference', methods=['POST'])
+def remove_media_reference(media_id: int):
+    user = session.get("user") # Ensure user is logged in
+    folder_to_remove = request.form.get('folder_to_remove')
+    media_type = request.form.get('media_type')
+
+    if not folder_to_remove:
+        flash("削除対象のフォルダが指定されていません。", "danger")
+    else:
+        success = utils.remove_media_reference_from_custom_folder(media_id, folder_to_remove)
+        if success: flash(f"カスタムフォルダ「{folder_to_remove}」からのメディア参照を削除しました。", "success")
+        else: flash("メディア参照の削除に失敗しました。エントリーが見つからない可能性があります。", "warning")
+    
+    redirect_to_folder = folder_to_remove # Redirect back to the folder from which reference was removed
+    if media_type == "video": return redirect(url_for('.video_page', current_folder=redirect_to_folder))
+    if media_type == "photo": return redirect(url_for('.photo_page', current_folder=redirect_to_folder))
+    return redirect(url_for(".index"))
+
 @bp.route('/download_media/<path:filepath_in_json>')
 def download_media_file(filepath_in_json: str):
-    # filepath_in_json is relative to 'static/uploads/'
     directory = os.path.join(current_app.static_folder, 'uploads')
     return send_from_directory(directory, filepath_in_json, as_attachment=True)
 
@@ -224,23 +245,30 @@ def delete_media(media_id: int):
     user = session.get("user")
     if user.get("role") != "admin":
         flash("権限がありません。", "danger")
-        return redirect(request.referrer or url_for('.index')) # Redirect to referrer or Decima index
-
-    # base_static_uploads_path for delete_media_entry is 'static/uploads'
-    base_static_uploads_abs = os.path.join(current_app.static_folder, 'uploads')
+        return redirect(request.referrer or url_for('.index'))
     
-    # Determine media type for redirect by fetching the entry first
-    media_entry = utils.get_media_entries() # Get all and find
-    entry_to_delete = next((e for e in media_entry if e.get("id") == media_id), None)
+    base_static_uploads_abs = os.path.join(current_app.static_folder, 'uploads')
+    # Store media details before attempting deletion for intelligent redirect
+    media_entries_list = utils.load_media_entries() # Use load_media_entries to get raw data
+    entry_to_delete = next((e for e in media_entries_list if e.get("id") == media_id), None)
+    
     redirect_url = url_for('.index') # Default redirect
     if entry_to_delete:
-        if entry_to_delete.get('media_type') == 'video':
-            redirect_url = url_for('.video_page', current_folder=entry_to_delete.get('custom_folder_name'))
-        elif entry_to_delete.get('media_type') == 'photo':
-            redirect_url = url_for('.photo_page', current_folder=entry_to_delete.get('custom_folder_name'))
+        media_type = entry_to_delete.get('media_type')
+        # Use request.form.get to get source_folder from the delete form in template
+        # This was added to the template in previous steps
+        source_folder = request.form.get('source_folder') 
+        if media_type == 'video':
+            redirect_url = url_for('.video_page', current_folder=source_folder if source_folder else None)
+        elif media_type == 'photo':
+            redirect_url = url_for('.photo_page', current_folder=source_folder if source_folder else None)
             
     if utils.delete_media_entry(media_id, base_static_uploads_abs):
         flash("メディアファイルを削除しました。", "success")
     else:
         flash("メディアファイルの削除に失敗しました。", "danger")
-    return redirect(request.referrer or redirect_url)
+    
+    # Try to redirect to request.referrer if available and reasonable, else to calculated redirect_url
+    # However, request.referrer can be unreliable or not what you want after a POST.
+    # The calculated redirect_url is safer.
+    return redirect(redirect_url)

--- a/app/principessina/templates/principessina/decima_photo_page.html
+++ b/app/principessina/templates/principessina/decima_photo_page.html
@@ -76,20 +76,58 @@
                     {% if entry.server_filepath %}
                     <img src="{{ url_for('static', filename=entry.server_filepath) }}" class="card-img-top" alt="{{ entry.title or entry.original_filename }}" style="object-fit: cover; height: 200px;">
                     {% endif %}
-                    <div class="card-body">
+                    <div class="card-body d-flex flex-column"> {# Use flex for footer alignment #}
                         <h6 class="card-title">{{ entry.title or entry.original_filename }}</h6>
                         <p class="card-text"><small class="text-muted">投稿者: {{ entry.uploader_username }}<br>
                         日時: {{ format_datetime_field(entry.upload_timestamp) }}
                         {% if entry.custom_folder_name %}
-                        <br>フォルダ: {{ entry.custom_folder_name }}
+                        <br>プライマリフォルダ: {{ entry.custom_folder_name }}
+                        {% else %}
+                        <br>プライマリフォルダ: 年月フォルダ
+                        {% endif %}
+                        {% if entry.referenced_in_custom_folders %}
+                        <br>参照フォルダ: {{ entry.referenced_in_custom_folders|join(', ') }}
                         {% endif %}
                         </small></p>
+
+                        {# "別のカスタムフォルダへコピー" Section #}
+                        {% if all_custom_photo_folders %} {# Use photo-specific variable #}
+                        <form method="POST" action="{{ url_for('principessina.copy_media_to_folder', media_id=entry.id) }}" class="mt-auto pt-2"> {# mt-auto for pushing to bottom #}
+                            {{ copy_form.csrf_token }}
+                            <input type="hidden" name="media_type" value="photo"> {# To redirect back to photo page #}
+                            <input type="hidden" name="source_folder" value="{{ current_folder_name if current_folder_name else '' }}">
+                            <div class="input-group input-group-sm mb-2">
+                                <label for="{{ copy_form.target_custom_folder.id }}_{{ entry.id }}" class="input-group-text">{{ copy_form.target_custom_folder.label.text }}</label>
+                                <select name="{{ copy_form.target_custom_folder.name }}" id="{{ copy_form.target_custom_folder.id }}_{{ entry.id }}" class="form-select form-select-sm">
+                                  <option value="">-- フォルダを選択 --</option>
+                                  {% for folder_name in all_custom_photo_folders %}
+                                    {% if folder_name != entry.custom_folder_name and folder_name not in entry.referenced_in_custom_folders %}
+                                      <option value="{{ folder_name }}">{{ folder_name }}</option>
+                                    {% endif %}
+                                  {% endfor %}
+                                </select>
+                                {{ copy_form.submit_copy(class="btn btn-outline-secondary btn-sm") }}
+                            </div>
+                        </form>
+                        {% endif %}
+
+                        {# "このフォルダから参照を削除" Button #}
+                        {% if current_folder_name and current_folder_name in entry.referenced_in_custom_folders and current_folder_name != entry.custom_folder_name %}
+                          <form method="POST" action="{{ url_for('principessina.remove_media_reference', media_id=entry.id) }}" style="display: block; margin-top: 5px;"> {# Changed to block for spacing #}
+                            {{ copy_form.csrf_token }} {# Assuming copy_form's token can be reused #}
+                            <input type="hidden" name="folder_to_remove" value="{{ current_folder_name }}">
+                            <input type="hidden" name="media_type" value="photo">
+                            <button type="submit" class="btn btn-outline-warning btn-sm w-100">このフォルダから参照を削除</button>
+                          </form>
+                        {% endif %}
                     </div>
                     <div class="card-footer">
-                        <a href="{{ url_for('principessina.download_media_file', filepath_in_json=entry.server_filepath) }}" class="btn btn-sm btn-outline-secondary">ダウンロード</a>
+                        <a href="{{ url_for('principessina.download_media_file', filepath_in_json=entry.server_filepath) }}" class="btn btn-sm btn-outline-dark">ダウンロード</a>
                         {% if user.role == 'admin' %}
                         <form method="POST" action="{{ url_for('principessina.delete_media', media_id=entry.id) }}" style="display: inline;" onsubmit="return confirm('この写真を本当に削除しますか？メディアファイルも完全に削除されます。');">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"> {# General CSRF if not using WTForms for this #}
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <input type="hidden" name="media_type" value="photo"> {# For redirecting back to photo page #}
+                            <input type="hidden" name="source_folder" value="{{ current_folder_name if current_folder_name else '' }}">
                             <button type="submit" class="btn btn-sm btn-danger">削除</button>
                         </form>
                         {% endif %}

--- a/app/principessina/templates/principessina/decima_video_page.html
+++ b/app/principessina/templates/principessina/decima_video_page.html
@@ -78,21 +78,60 @@
                     </div>
                     <div class="card-body">
                         <video controls width="100%" style="max-height: 300px;" class="mb-2 rounded">
-                            {# server_filepath is like 'principessina/videos/YYYY/MM/WW/filename.ext' #}
-                            {# url_for('static', filename=...) expects path relative to static folder #}
                             <source src="{{ url_for('static', filename=entry.server_filepath) }}" type="video/{{ entry.original_filename.split('.')[-1]|lower if '.' in entry.original_filename else 'mp4' }}">
                             お使いのブラウザはビデオタグをサポートしていません。
                         </video>
                         <p class="card-text"><small class="text-muted">投稿者: {{ entry.uploader_username }}<br>
                         日時: {{ format_datetime_field(entry.upload_timestamp) }}
                         {% if entry.custom_folder_name %}
-                        <br>フォルダ: {{ entry.custom_folder_name }}
+                        <br>プライマリフォルダ: {{ entry.custom_folder_name }}
+                        {% else %}
+                        <br>プライマリフォルダ: 年月フォルダ
+                        {% endif %}
+                        {% if entry.referenced_in_custom_folders %}
+                        <br>参照フォルダ: {{ entry.referenced_in_custom_folders|join(', ') }}
                         {% endif %}
                         </small></p>
-                        <a href="{{ url_for('principessina.download_media_file', filepath_in_json=entry.server_filepath) }}" class="btn btn-sm btn-outline-secondary">ダウンロード</a>
+                        
+                        {# "別のカスタムフォルダへコピー" Section #}
+                        {% if all_custom_video_folders %}
+                        <form method="POST" action="{{ url_for('principessina.copy_media_to_folder', media_id=entry.id) }}" class="mt-2">
+                            {{ copy_form.csrf_token }}
+                            <input type="hidden" name="media_type" value="video"> {# To redirect back to video page #}
+                             <input type="hidden" name="source_folder" value="{{ current_folder_name if current_folder_name else '' }}">
+                            <div class="input-group input-group-sm mb-2">
+                                <label for="{{ copy_form.target_custom_folder.id }}_{{ entry.id }}" class="input-group-text">{{ copy_form.target_custom_folder.label.text }}</label>
+                                <select name="{{ copy_form.target_custom_folder.name }}" id="{{ copy_form.target_custom_folder.id }}_{{ entry.id }}" class="form-select form-select-sm">
+                                  <option value="">-- フォルダを選択 --</option>
+                                  {% for folder_name in all_custom_video_folders %}
+                                    {# Exclude if it's the primary custom folder or already referenced #}
+                                    {% if folder_name != entry.custom_folder_name and folder_name not in entry.referenced_in_custom_folders %}
+                                      <option value="{{ folder_name }}">{{ folder_name }}</option>
+                                    {% endif %}
+                                  {% endfor %}
+                                </select>
+                                {{ copy_form.submit_copy(class="btn btn-outline-secondary btn-sm") }}
+                            </div>
+                        </form>
+                        {% endif %}
+
+                        {# "このフォルダから参照を削除" Button #}
+                        {% if current_folder_name and current_folder_name in entry.referenced_in_custom_folders and current_folder_name != entry.custom_folder_name %}
+                          <form method="POST" action="{{ url_for('principessina.remove_media_reference', media_id=entry.id) }}" style="display: inline-block; margin-top: 5px;">
+                            {{ copy_form.csrf_token }} {# Assuming copy_form's token can be reused or a general one #}
+                            <input type="hidden" name="folder_to_remove" value="{{ current_folder_name }}">
+                            <input type="hidden" name="media_type" value="video">
+                            <button type="submit" class="btn btn-outline-warning btn-sm">このフォルダから参照を削除</button>
+                          </form>
+                        {% endif %}
+                    </div>
+                    <div class="card-footer">
+                        <a href="{{ url_for('principessina.download_media_file', filepath_in_json=entry.server_filepath) }}" class="btn btn-sm btn-outline-dark">ダウンロード</a>
                         {% if user.role == 'admin' %}
                         <form method="POST" action="{{ url_for('principessina.delete_media', media_id=entry.id) }}" style="display: inline;" onsubmit="return confirm('この動画を本当に削除しますか？メディアファイルも完全に削除されます。');">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"> {# General CSRF if not using WTForms for this #}
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                             <input type="hidden" name="media_type" value="video"> {# For redirecting back to video page #}
+                             <input type="hidden" name="source_folder" value="{{ current_folder_name if current_folder_name else '' }}">
                             <button type="submit" class="btn btn-sm btn-danger">削除</button>
                         </form>
                         {% endif %}


### PR DESCRIPTION
This commit introduces the ability for you to "copy" (add a reference to) existing media items (videos and photos) to other custom folders within the Decima module. The actual media file remains in its original location.

Key changes:

- Data Structure (`app/principessina/utils.py`):
    - Media entries in `principessina_media.json` now include a `referenced_in_custom_folders: List[str]` field, initialized as an empty list upon new media creation (`add_media_entry` updated).
    - `get_media_entries` logic was updated to correctly display media in a custom folder if it's either primarily in that folder OR referenced in that folder's `referenced_in_custom_folders` list. Year/week folder view remains for non-custom-primary items.

- Utility Functions (`app/principessina/utils.py`):
    - Added `add_media_reference_to_custom_folder(media_id, target_folder)`: Appends a custom folder name to the media's reference list.
    - Added `remove_media_reference_from_custom_folder(media_id, target_folder)`: Removes a custom folder name from the media's reference list.

- Forms (`app/principessina/forms.py`):
    - Created `CopyMediaToCustomFolderForm` with a `SelectField` for choosing the target custom folder and a button to confirm.

- Templates (`decima_video_page.html`, `decima_photo_page.html`):
    - Integrated `CopyMediaToCustomFolderForm` into each media item's display, allowing you to select a target custom folder and initiate the "copy." The select field choices are dynamically populated and filtered.
    - Added a "Remove reference from this folder" button, conditionally displayed when viewing a media item via a reference in a custom folder.

- Routes (`app/principessina/routes.py`):
    - Updated `video_page()` and `photo_page()` to instantiate and pass the `CopyMediaToCustomFolderForm` and the list of all available custom folders (for that media type) to their respective templates.
    - Added new route `/media/<int:media_id>/copy_to_folder` (POST) to handle the form action, call the appropriate utility function, flash a message, and redirect. Form choices are repopulated before validation.
    - Added new route `/media/<int:media_id>/remove_reference` (POST) to handle the "remove reference" action, call the utility function, flash a message, and redirect.