### PR TITLE
fix(Calendario): Update shift stats immediately on click-delete

### DIFF
--- a/static/js/shift_manager.js
+++ b/static/js/shift_manager.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
           emps.splice(idx, 1);
           input.value = emps.join(',');
           span.remove();
+          updateShiftCounts(); // Added this line
         }
       });
     }


### PR DESCRIPTION
In the shift management page (`/calendario/shift`), when an employee assignment was removed by clicking on their name in a calendar cell, the summary statistics (work days, off days) at the top of the page were not updating immediately. This was because the `updateShiftCounts()` JavaScript function was not called after this specific action.

This commit modifies `static/js/shift_manager.js` to call `updateShiftCounts()` after an assignment is removed via click, ensuring that the statistics are refreshed promptly, providing immediate visual feedback to you, consistent with the behavior during drag-and-drop operations.