### PR TITLE
Okay, I've made some changes to address a `jinja2.exceptions.Undefine…

### DIFF
--- a/app/calendario/forms.py
+++ b/app/calendario/forms.py
@@ -59,3 +59,11 @@ class ShiftRulesForm(FlaskForm):
     required_attributes = StringField("属性ごとの必要人数", validators=[Optional()])
     submit = SubmitField("保存")
 
+
+class ShiftManagementForm(FlaskForm):
+    """Minimal form for CSRF token generation on the shift management page."""
+    # No fields needed other than what FlaskForm provides (e.g., CSRF token)
+    # If we needed a submit button tied to this specific form for some reason:
+    # submit_shifts = SubmitField('更新') # Example, not strictly needed if using JS/other buttons
+    pass
+

--- a/app/calendario/routes.py
+++ b/app/calendario/routes.py
@@ -15,7 +15,7 @@ from flask import (
 )
 
 from . import bp
-from .forms import EventForm, StatsForm, ShiftRulesForm
+from .forms import EventForm, StatsForm, ShiftRulesForm, ShiftManagementForm # Added ShiftManagementForm
 from . import utils
 import config
 from typing import Dict, List
@@ -358,11 +358,15 @@ def shift():
     rules, defined_attributes = utils.load_rules()
     rules_data_for_js = {"rules": rules, "defined_attributes": defined_attributes}
 
+    # Instantiate ShiftManagementForm for CSRF token
+    csrf_form = ShiftManagementForm()
+
     return render_template(
         "shift_manager.html",
         user=user,
         month=month,
-        rules_for_js=rules_data_for_js, # Pass rules data to template
+        rules_for_js=rules_data_for_js, 
+        form=csrf_form, # Pass the CSRF-only form
         weeks=weeks,
         employees=employees,
         assignments=assignments, 

--- a/app/calendario/templates/calendario/shift_manager.html
+++ b/app/calendario/templates/calendario/shift_manager.html
@@ -78,8 +78,8 @@
 </div>
 
 <form method="post">
+    {{ form.hidden_tag() }} {# Replaced csrf_token() with Flask-WTF form hidden_tag #}
     <input type="hidden" name="action" value="complete" id="action-field">
-    {{ csrf_token() }} {# Added CSRF token if using Flask-WTF globally #}
     <table class="calendar table table-bordered">
         <thead class="table-light">
             <tr>


### PR DESCRIPTION
…dError: 'csrf_token' is undefined` that was occurring on the shift management page (`/calendario/shift`).

It seems this error was happening because `{{ csrf_token() }}` was being called directly in the template, but a Flask-WTF form instance wasn't properly set up and provided to make this macro available.

Here's how I resolved it:
1.  I created a minimal `ShiftManagementForm(FlaskForm)` in `app/calendario/forms.py`.
2.  Then, I instantiated this form within the `shift()` route in `app/calendario/routes.py` and made sure it was passed to the template.
3.  Finally, I replaced `{{ csrf_token() }}` with `{{ form.hidden_tag() }}` in `app/calendario/templates/calendario/shift_manager.html`. This ensures the CSRF token and any other hidden fields from the form instance are rendered correctly.

This approach makes sure that Flask-WTF's CSRF protection is properly implemented for your shift management form.