### PR TITLE
fix(Calendario): Resolve 'regex_search' filter error and improve titl…

### DIFF
--- a/app/calendario/templates/calendario/month_view.html
+++ b/app/calendario/templates/calendario/month_view.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% from 'macros.html' import format_datetime_field %} {# Assuming this macro might be used for event times if added #}
+{% from 'macros.html' import format_datetime_field %}
 
 {% block title %}カレンダー - {{ month.strftime('%Y-%m') }}{% endblock %}
 
 {% block content %}
-<div class="container mt-4"> {# Added container for consistency #}
+<div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>{{ month.strftime('%Y-%m') }}</h1>
         <div>
@@ -23,7 +23,7 @@
         </div>
     </div>
 
-    <table class="calendar table table-bordered" style="table-layout: fixed;"> {# Added table-bordered and fixed layout #}
+    <table class="calendar table table-bordered" style="table-layout: fixed;">
         <thead class="table-light">
             <tr>
                 <th style="width: 14.28%;">月</th>
@@ -32,7 +32,7 @@
                 <th style="width: 14.28%;">木</th>
                 <th style="width: 14.28%;">金</th>
                 <th style="width: 14.28%;">土</th>
-                <th style="width: 14.28%;">日</th>
+                <th style.width: 14.28%;">日</th>
             </tr>
         </thead>
         <tbody>
@@ -40,24 +40,24 @@
             <tr>
                 {% for d in week %}
                 <td class="{% if d.month != month.month %}other-month text-muted bg-light{% else %}calendar-day{% endif %}"
-                    style="vertical-align: top; height: 120px; overflow-y: auto;"> {# Added height and overflow #}
+                    style="vertical-align: top; height: 120px; overflow-y: auto;">
                     <div class="day-number fw-bold" style="font-size: 0.9em;">{{ d.day }}</div>
 
                     <div class="event-grid-container">
                         {% for ev in events_by_date.get(d.isoformat(), []) %}
                             <div class="event-grid-item">
                                 <span class="calendar-event-text-compact">
-                                    {# Attempt to extract time if present in title, e.g., "10:00 Meeting" #}
-                                    {% set time_match = ev.title|regex_search('^(\\d{1,2}:\\d{2})\\s*(.*)$') %}
-                                    {% if time_match %}
-                                        <small class="text-muted">{{ time_match.group(1) }}</small> {{ time_match.group(2) }}
-                                    {% else %}
-                                        {{ ev.title }}
+                                    {% if ev.display_time %}
+                                        <span class="event-time" style="font-weight: bold;">{{ ev.display_time }}</span>&nbsp;
+                                    {% endif %}
+                                    <span class="event-title">{{ ev.cleaned_title }}</span>
+                                    {% if ev.employee and ev.category == 'shift' %}
+                                        <small class="text-muted ms-1">({{ ev.employee }})</small>
                                     {% endif %}
                                 </span>
-                                {# Example for edit button, adjust as needed #}
-                                {% if user.role == 'admin' or ev.author == user.username %} {# Basic permission example #}
-                                <a href="{{ url_for('calendario.edit_event', event_id=ev.id) }}" class="btn btn-primary btn-xs-custom mt-1">編集</a>
+
+                                {% if user.role == 'admin' or ev.get('author') == user.username %} {# Assuming events might have an 'author' #}
+                                <a href="{{ url_for('calendario.edit_event', event_id=ev.id) }}" class="btn btn-primary btn-xs-custom mt-1" style="padding: 0.1rem 0.2rem; font-size: 0.7em;">編集</a>
                                 {% endif %}
                             </div>
                         {% endfor %}

--- a/app/calendario/templates/calendario/week_view.html
+++ b/app/calendario/templates/calendario/week_view.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% from 'macros.html' import format_datetime_field %} {# Assuming this might be used for event times #}
+{% from 'macros.html' import format_datetime_field %}
 
 {% block title %}{{ start.strftime('%Y-%m-%d') }} - {{ (start + timedelta(days=6)).strftime('%Y-%m-%d') }} 週カレンダー{% endblock %}
 
 {% block content %}
-<div class="container-fluid mt-3"> {# Use container-fluid for wider view #}
+<div class="container-fluid mt-3">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>{{ start.strftime('%Y-%m-%d') }} - {{ (start + timedelta(days=6)).strftime('%Y-%m-%d') }} 週</h1>
         <div>
@@ -26,7 +26,7 @@
     <table class="calendar-grid table table-bordered" style="table-layout: fixed;">
         <thead class="table-light">
             <tr>
-                <th class="time-col" style="width: 80px;">時間</th> {# Fixed width for time column #}
+                <th class="time-col" style="width: 80px;">時間</th>
                 {% for day in week_days %}
                 <th class="day-col {% if day.isoformat() == today_date %}table-info{% endif %}" style="width: calc((100% - 80px) / 7);">
                     {{ day.strftime('%a') }}<br>{{ day.strftime('%m/%d') }}
@@ -40,14 +40,20 @@
                 <td class="time-slot-label table-light">終日</td>
                 {% for day in week_days %}
                 <td class="calendar-cell all-day-cell {% if day.isoformat() == today_date %}table-info{% endif %}" style="height: auto; min-height: 60px; overflow-y: auto;">
-                    <div class="event-grid-container-week"> {# Applied class #}
+                    <div class="event-grid-container-week">
                         {% for event in structured_events.get(day.isoformat(), {}).get('all_day', []) %}
-                        <div class="event-grid-item"> {# Applied class #}
-                            <span class="calendar-event-text-compact"> {# Applied class #}
-                                {{ event.title }}
-                                {% if event.employee %}({{ event.employee }}){% endif %}
+                        <div class="event-grid-item">
+                            <span class="calendar-event-text-compact">
+                                {# Use pre-parsed fields #}
+                                {% if event.display_time %}
+                                    <span class="event-time" style="font-weight: bold;">{{ event.display_time }}</span>&nbsp;
+                                {% endif %}
+                                <span class="event-title">{{ event.cleaned_title }}</span>
+                                {% if event.employee and event.category == 'shift' %} {# Show employee only for shifts or as needed #}
+                                    <small class="text-muted ms-1">({{ event.employee }})</small>
+                                {% endif %}
                             </span>
-                            {% if user.role == 'admin' or event.author == user.username %} {# Basic permission example #}
+                            {% if user.role == 'admin' or event.get('author') == user.username %}
                                 <a href="{{ url_for('calendario.edit_event', event_id=event.id) }}" class="btn btn-primary btn-xs-custom mt-1" style="padding: 0.1rem 0.2rem; font-size: 0.7em;">編集</a>
                             {% endif %}
                         </div>
@@ -63,14 +69,21 @@
                 <td class="time-slot-label table-light">{{ slot }}</td>
                 {% for day in week_days %}
                 <td class="calendar-cell {% if day.isoformat() == today_date %}table-info{% endif %}" style="height: 70px; overflow-y: auto;">
-                     <div class="event-grid-container-week"> {# Applied class #}
+                     <div class="event-grid-container-week">
                         {% for event in structured_events.get(day.isoformat(), {}).get(slot, []) %}
-                        <div class="event-grid-item"> {# Applied class #}
-                            <span class="calendar-event-text-compact"> {# Applied class #}
-                                {{ event.title }}
-                                {% if event.employee %}({{ event.employee }}){% endif %}
+                        <div class="event-grid-item">
+                            <span class="calendar-event-text-compact">
+                                {# Use pre-parsed fields. For timed events, display_time should typically exist if parsed from title. #}
+                                {# If not, it means the original title didn't have a time prefix. #}
+                                {% if event.display_time %}
+                                    <span class="event-time" style="font-weight: bold;">{{ event.display_time }}</span>&nbsp;
+                                {% endif %}
+                                <span class="event-title">{{ event.cleaned_title }}</span>
+                                {% if event.employee and event.category == 'shift' %}
+                                    <small class="text-muted ms-1">({{ event.employee }})</small>
+                                {% endif %}
                             </span>
-                             {% if user.role == 'admin' or event.author == user.username %} {# Basic permission example #}
+                             {% if user.role == 'admin' or event.get('author') == user.username %}
                                 <a href="{{ url_for('calendario.edit_event', event_id=event.id) }}" class="btn btn-primary btn-xs-custom mt-1" style="padding: 0.1rem 0.2rem; font-size: 0.7em;">編集</a>
                             {% endif %}
                         </div>
@@ -92,7 +105,4 @@
     <p class="mt-3"><a href="{{ url_for('index') }}" class="btn btn-outline-secondary">メインページに戻る</a></p>
 </div>
 
-{# Remove inline styles, assuming they are in static/css/style.css or base.html #}
-{# The new classes .calendar-event-text-compact, .event-grid-container-week, .event-grid-item, .btn-xs-custom
-   are expected to be defined in the main style.css file. #}
 {% endblock %}


### PR DESCRIPTION
…e display

This commit fixes the `jinja2.exceptions.TemplateAssertionError: No filter named 'regex_search'` that occurred in `month_view.html` and potentially `week_view.html`. The error was caused by attempting to use a non-standard Jinja2 filter to parse time from event titles directly in the templates.

The fix involves:
1.  **Backend Title Parsing (`app/calendario/routes.py` - `index()` function):**
    - Event titles are now pre-processed in the Python route handler.
    - A regular expression (`^(\d{1,2}:\d{2})\s*(.*)$`) is used to check if an event title starts with a "HH:MM " time prefix.
    - If a match is found, the event dictionary is augmented with two new keys: `display_time` (containing the extracted time string) and `cleaned_title` (containing the rest of the title).
    - If no match, `display_time` is set to `None` and `cleaned_title` defaults to the original title.
    - This processing is applied to events used in both `events_by_date` (for month view) and `structured_events` (for week view).

2.  **Template Updates (`month_view.html`, `week_view.html`):**
    - Removed all uses of the `|regex_search` filter.
    - Updated the event display logic to use the new `display_time` and `cleaned_title` keys. Time is now conditionally displayed (and bolded) if `display_time` is present, followed by the `cleaned_title`.

This approach centralizes the title parsing logic in Python, simplifies the templates, and resolves the runtime error.