### PR TITLE
fix(Calendario): Correctly display Sunday column in month view

### DIFF
--- a/app/calendario/templates/calendario/month_view.html
+++ b/app/calendario/templates/calendario/month_view.html
@@ -32,7 +32,7 @@
                 <th style="width: 14.28%;">木</th>
                 <th style="width: 14.28%;">金</th>
                 <th style="width: 14.28%;">土</th>
-                <th style.width: 14.28%;">日</th>
+                <th style="width: 14.28%;">日</th> {# Corrected style attribute #}
             </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
This commit fixes an issue in the month view of the main calendar (`/calendario` or `/calendario?view=month`) where the Sunday column was being cut off or not rendered properly.

The issue was caused by a typo in the `style` attribute of the `<th>` element for Sunday in `app/calendario/templates/calendario/month_view.html`. The attribute was written as `style.width: 14.28%;` instead of the correct `style="width: 14.28%;"`.

This typo prevented the browser from applying the intended width to the last column, especially problematic with `table-layout: fixed;`. The `style` attribute has been corrected.