### PR TITLE
style(Calendario): Adjust edit button layout in main calendar views

### DIFF
--- a/app/calendario/templates/calendario/month_view.html
+++ b/app/calendario/templates/calendario/month_view.html
@@ -32,7 +32,7 @@
                 <th style="width: 14.28%;">木</th>
                 <th style="width: 14.28%;">金</th>
                 <th style="width: 14.28%;">土</th>
-                <th style="width: 14.28%;">日</th> {# Corrected style attribute #}
+                <th style="width: 14.28%;">日</th>
             </tr>
         </thead>
         <tbody>
@@ -45,8 +45,8 @@
 
                     <div class="event-grid-container">
                         {% for ev in events_by_date.get(d.isoformat(), []) %}
-                            <div class="event-grid-item">
-                                <span class="calendar-event-text-compact">
+                            <div class="event-grid-item d-flex align-items-center justify-content-between">
+                                <span class="calendar-event-text-compact flex-grow-1" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
                                     {% if ev.display_time %}
                                         <span class="event-time" style="font-weight: bold;">{{ ev.display_time }}</span>&nbsp;
                                     {% endif %}
@@ -56,8 +56,8 @@
                                     {% endif %}
                                 </span>
 
-                                {% if user.role == 'admin' or ev.get('author') == user.username %} {# Assuming events might have an 'author' #}
-                                <a href="{{ url_for('calendario.edit_event', event_id=ev.id) }}" class="btn btn-primary btn-xs-custom mt-1" style="padding: 0.1rem 0.2rem; font-size: 0.7em;">編集</a>
+                                {% if user.role == 'admin' or ev.get('author') == user.username %}
+                                <a href="{{ url_for('calendario.edit_event', event_id=ev.id) }}" class="btn btn-primary btn-xs-custom ms-2" style="white-space: nowrap;">編集</a>
                                 {% endif %}
                             </div>
                         {% endfor %}

--- a/app/calendario/templates/calendario/week_view.html
+++ b/app/calendario/templates/calendario/week_view.html
@@ -42,19 +42,18 @@
                 <td class="calendar-cell all-day-cell {% if day.isoformat() == today_date %}table-info{% endif %}" style="height: auto; min-height: 60px; overflow-y: auto;">
                     <div class="event-grid-container-week">
                         {% for event in structured_events.get(day.isoformat(), {}).get('all_day', []) %}
-                        <div class="event-grid-item">
-                            <span class="calendar-event-text-compact">
-                                {# Use pre-parsed fields #}
+                        <div class="event-grid-item d-flex align-items-center justify-content-between">
+                            <span class="calendar-event-text-compact flex-grow-1" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
                                 {% if event.display_time %}
                                     <span class="event-time" style="font-weight: bold;">{{ event.display_time }}</span>&nbsp;
                                 {% endif %}
                                 <span class="event-title">{{ event.cleaned_title }}</span>
-                                {% if event.employee and event.category == 'shift' %} {# Show employee only for shifts or as needed #}
+                                {% if event.employee and event.category == 'shift' %}
                                     <small class="text-muted ms-1">({{ event.employee }})</small>
                                 {% endif %}
                             </span>
                             {% if user.role == 'admin' or event.get('author') == user.username %}
-                                <a href="{{ url_for('calendario.edit_event', event_id=event.id) }}" class="btn btn-primary btn-xs-custom mt-1" style="padding: 0.1rem 0.2rem; font-size: 0.7em;">編集</a>
+                                <a href="{{ url_for('calendario.edit_event', event_id=event.id) }}" class="btn btn-primary btn-xs-custom ms-2" style="padding: 0.1rem 0.2rem; font-size: 0.7em; white-space: nowrap;">編集</a>
                             {% endif %}
                         </div>
                         {% endfor %}
@@ -71,10 +70,8 @@
                 <td class="calendar-cell {% if day.isoformat() == today_date %}table-info{% endif %}" style="height: 70px; overflow-y: auto;">
                      <div class="event-grid-container-week">
                         {% for event in structured_events.get(day.isoformat(), {}).get(slot, []) %}
-                        <div class="event-grid-item">
-                            <span class="calendar-event-text-compact">
-                                {# Use pre-parsed fields. For timed events, display_time should typically exist if parsed from title. #}
-                                {# If not, it means the original title didn't have a time prefix. #}
+                        <div class="event-grid-item d-flex align-items-center justify-content-between">
+                            <span class="calendar-event-text-compact flex-grow-1" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
                                 {% if event.display_time %}
                                     <span class="event-time" style="font-weight: bold;">{{ event.display_time }}</span>&nbsp;
                                 {% endif %}
@@ -84,7 +81,7 @@
                                 {% endif %}
                             </span>
                              {% if user.role == 'admin' or event.get('author') == user.username %}
-                                <a href="{{ url_for('calendario.edit_event', event_id=event.id) }}" class="btn btn-primary btn-xs-custom mt-1" style="padding: 0.1rem 0.2rem; font-size: 0.7em;">編集</a>
+                                <a href="{{ url_for('calendario.edit_event', event_id=event.id) }}" class="btn btn-primary btn-xs-custom ms-2" style="padding: 0.1rem 0.2rem; font-size: 0.7em; white-space: nowrap;">編集</a>
                             {% endif %}
                         </div>
                         {% endfor %}


### PR DESCRIPTION
This commit modifies the layout of event items in the main calendar views (month and week) to position the "Edit" button horizontally next to the event text, rather than below it. This helps to reduce the vertical height of date cells when multiple events are present.

Key changes:

- **Templates (`month_view.html`, `week_view.html`):**
    - Applied Bootstrap Flexbox utilities (`d-flex`, `align-items-center`, `justify-content-between`) to the `.event-grid-item` divs.
    - Wrapped event textual information (time, title, employee for shifts) in a `<span>` with `flex-grow-1` to allow it to take available space.
    - Added `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` to the event text wrapper to handle long titles gracefully.
    - Ensured the "Edit" button (`<a>` tag with `.btn-xs-custom`) is a direct child of the flex container, positioned to the right of the text.
    - Added `ms-2` (left margin) and `white-space: nowrap` to the edit button for better spacing and to prevent button text wrapping.

This change improves the compactness and scannability of the main calendar views by ensuring a more consistent horizontal flow for each event's information and its associated action button.