### PR TITLE
Fix: Update Calendario UI elements

### DIFF
--- a/app/calendario/templates/calendario/shift_manager.html
+++ b/app/calendario/templates/calendario/shift_manager.html
@@ -54,13 +54,17 @@
     <div class="card-header">今月の集計</div>
     <div class="card-body" data-current-month="{{ month.strftime('%Y-%m') }}">
         {% if employees %}
-            {% for emp in employees %}
-                <p style="margin: 5px 0;">
-                    {{ emp }}:
-                    勤務日数 <span class="work-count" data-emp="{{ emp }}">{{ counts.get(emp, 0) }}</span>日,
-                    休日数 <span class="off-count" data-emp="{{ emp }}">{{ off_counts.get(emp, 0) }}</span>日
-                </p>
-            {% endfor %}
+                <div class="employee-summary-grid"> {# New grid container #}
+                    {% for emp in employees %}
+                        <div class="employee-summary-item user-summary-{{ emp|lower }}"> {# New grid item for each employee #}
+                            <p style="margin: 5px 0;">
+                                {{ emp }}:<br> {# Added <br> for better readability if text wraps #}
+                                勤務日数 <span class="work-count" data-emp="{{ emp }}">{{ counts.get(emp, 0) }}</span>日,<br>
+                                休日数 <span class="off-count" data-emp="{{ emp }}">{{ off_counts.get(emp, 0) }}</span>日
+                            </p>
+                        </div>
+                    {% endfor %}
+                </div>
         {% else %}<p>表示する従業員がいません。</p>{% endif %}
     </div>
 </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -307,12 +307,14 @@ ul {
     font-size: 0.75em;
     line-height: 1.2;
     border-radius: 0.2rem;
+    text-decoration: none !important;
 }
 
 .btn-custom-edit:hover {
     background-color: darkblue !important;
     border-color: darkblue !important;
     color: white !important;
+    text-decoration: none !important;
 }
 
 .btn-custom-copy {
@@ -346,3 +348,28 @@ ul {
     border-color: #A0522D !important;
     color: white !important;
 }
+
+.employee-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr); /* 4 equal columns */
+    gap: 10px; /* Adjust gap as needed */
+}
+
+.employee-summary-item {
+    padding: 10px; /* Added/Adjusted padding */
+    border-width: 2px;
+    border-style: solid;
+    /* Default border color if a specific user class isn't matched, or remove if not needed */
+    border-color: #ccc; /* Light grey default, can be overridden */
+    margin-bottom: 5px; /* Add some space between items if the gap isn't enough vertically */
+}
+
+/* User-specific borders */
+.user-summary-raito { border-color: #f0f0f0; } /* Light Grey for 'raito' as white might be invisible */
+.user-summary-hitomi { border-color: #0000FF; } /* Vivid Blue */
+.user-summary-sara { border-color: #FFA500; } /* Vivid Orange */
+.user-summary-jun { border-color: #800020; } /* Burgundy */
+.user-summary-nanchan { border-color: #808000; } /* Khaki */
+.user-summary-hachi { border-color: #40E0D0; } /* Light Turquoise */
+.user-summary-kie { border-color: #FFC107; } /* Dark Yellow (Amber) */
+.user-summary-gumi { border-color: #C71585; } /* Dark Pink (MediumVioletRed) */


### PR DESCRIPTION
This commit addresses three UI issues on the Calendario page:

1.  Removed the underline from the 'Edit' (編集) button text. The CSS for `.btn-custom-edit` and its hover state in `static/css/style.css` was updated to include `text-decoration: none !important;`.

2.  Reformatted the 'Monthly Summary' (今月の集計) display. The layout in `app/calendario/templates/calendario/shift_manager.html` was changed to a 4-column grid. CSS for `.employee-summary-grid` was added to `static/css/style.css` to support this.

3.  Added colored borders to your summaries in the 'Monthly Summary'. User-specific classes (`user-summary-<username>`) were added in `shift_manager.html`, and corresponding CSS rules for border colors and padding were added to `style.css` as per the requirements. The color for 'raito' was changed to light grey (#f0f0f0) for better visibility against a white background.