### PR TITLE
Fix: カレンダーレイアウトと表示の大幅改善 (セル内スクロール導入)

### DIFF
--- a/app/calendario/templates/calendario/month_view.html
+++ b/app/calendario/templates/calendario/month_view.html
@@ -41,12 +41,12 @@
             <tr>
                 {% for d in week %}
                 <td class="{% if d.month != month.month %}other-month text-muted bg-light{% else %}calendar-day{% endif %}"
-                    {% if d.month == month.month %}data-date="{{ d.isoformat() }}"{% endif %}
-                    style="vertical-align: top; height: 120px; overflow-y: auto; padding: 2px;"> {# Reduced padding for more space #}
-                    <div class="day-number fw-bold" style="font-size: 0.9em; margin-bottom: 2px;">{{ d.day }}</div>
+                    {% if d.month == month.month %}data-date="{{ d.isoformat() }}"{% endif %}>
+                    <div class="cell-content-wrapper">
+                        <div class="day-number fw-bold">{{ d.day }}</div>
 
-                    {# Removed the all-encompassing event-grid-container #}
-                    {% set events_for_day = events_by_date.get(d.isoformat(), []) %}
+                        {# Removed the all-encompassing event-grid-container #}
+                        {% set events_for_day = events_by_date.get(d.isoformat(), []) %}
                     {% for ev in events_for_day %}
                         {# Logic to open shift-grid-container #}
                         {% if ev.category == 'shift' and (loop.first or loop.previtem.category != 'shift') %}
@@ -89,6 +89,7 @@
                         </div> {# Close shift-grid-container #}
                         {% endif %}
                     {% endfor %}
+                    </div> {# Close cell-content-wrapper #}
                 </td>
                 {% endfor %}
             </tr>

--- a/app/calendario/templates/calendario/shift_manager.html
+++ b/app/calendario/templates/calendario/shift_manager.html
@@ -81,31 +81,33 @@
             {% for d in week %}
                 <td class="{% if d.month != month.month %}other-month text-muted{% else %}shift-cell{% endif %}"
                     data-date="{{ d.isoformat() }}"
-                    style="{% if d.month != month.month %}background-color: #f8f9fa;{% endif %}">
-                    <div class="day-number">{{ d.day }}</div>
-                    <div class="violation-icons"></div>
-                    {# This div will now contain all events, including shifts and other event types #}
-                    <div class="assignments shift-manager-assignment-grid">
-                        {# Iterate through all events for the day from the new variable #}
-                        {% for ev in all_events_by_date.get(d.isoformat(), []) %}
-                            {% if ev.category == 'shift' %}
-                                {# Shifts are draggable and clickable for management #}
-                                <span class="assigned event-shift-item initial-text-{{ ev.employee|lower|replace(' ', '_') }}" draggable="true" data-emp="{{ ev.employee }}">{{ ev.employee | initials }}</span>
-                            {% else %}
-                                {# Other events are for display only, not draggable in shift manager #}
-                                <div class="event-grid-item event-{{ ev.category }}" title="{{ ev.cleaned_title }}{% if ev.employee %} ({{ev.employee}}){% endif %}">
-                                    {% if ev.display_time %}<span class="event-time">{{ ev.display_time }}</span>{% endif %}
-                                    {{ ev.cleaned_title }}
-                                    {% if ev.employee and ev.category != 'shift' %}
-                                        <small class="event-employee"> ({{ ev.employee }})</small>
-                                    {% endif %}
-                                </div>
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-                    {# The hidden input still needs to be populated ONLY with shift employees #}
-                    {# The 'assignments' variable passed to the template now specifically holds shift employees for form submission #}
-                    <input type="hidden" name="d-{{ d.isoformat() }}" value="{{ ','.join(assignments.get(d.isoformat(), [])) }}">
+                    {% if d.month != month.month %}style="background-color: #f8f9fa;"{% endif %}> {# Keep conditional background style #}
+                    <div class="cell-content-wrapper">
+                        <div class="day-number">{{ d.day }}</div>
+                        <div class="violation-icons"></div>
+                        {# This div will now contain all events, including shifts and other event types #}
+                        <div class="assignments shift-manager-assignment-grid">
+                            {# Iterate through all events for the day from the new variable #}
+                            {% for ev in all_events_by_date.get(d.isoformat(), []) %}
+                                {% if ev.category == 'shift' %}
+                                    {# Shifts are draggable and clickable for management #}
+                                    <span class="assigned event-shift-item initial-text-{{ ev.employee|lower|replace(' ', '_') }}" draggable="true" data-emp="{{ ev.employee }}">{{ ev.employee | initials }}</span>
+                                {% else %}
+                                    {# Other events are for display only, not draggable in shift manager #}
+                                    <div class="event-grid-item event-{{ ev.category }}" title="{{ ev.cleaned_title }}{% if ev.employee %} ({{ev.employee}}){% endif %}">
+                                        {% if ev.display_time %}<span class="event-time">{{ ev.display_time }}</span>{% endif %}
+                                        {{ ev.cleaned_title }}
+                                        {% if ev.employee and ev.category != 'shift' %}
+                                            <small class="event-employee"> ({{ ev.employee }})</small>
+                                        {% endif %}
+                                    </div>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                        {# The hidden input still needs to be populated ONLY with shift employees #}
+                        {# The 'assignments' variable passed to the template now specifically holds shift employees for form submission #}
+                        <input type="hidden" name="d-{{ d.isoformat() }}" value="{{ ','.join(assignments.get(d.isoformat(), [])) }}">
+                    </div> {# Close cell-content-wrapper #}
                 </td>
             {% endfor %}
             </tr>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -76,24 +76,28 @@ table { /* General table styling */
 }
 
 /* Calendar specific table layouts */
-.calendar, .calendar-grid {
-    table-layout: auto;
-    width: 100%; /* Ensure it's still 100% */
+.calendar, .calendar-grid { /* .calendar-grid might be for other views, ensure fixed layout is desired there too, or make selector more specific e.g. table.calendar */
+    table-layout: fixed; /* Changed from auto */
+    width: 100%;
 }
 
-/* Remove word-break from calendar cells if item content itself handles truncation */
+/* Styles for calendar cells */
 .calendar td.calendar-day,
-.calendar-grid td.calendar-cell {
-    /* If there were word-break: break-all; or overflow-wrap: break-word; here, consider removing */
-    /* For now, no specific removal, assuming they don't exist or aren't problematic */
+.calendar td.shift-cell {
+    height: 150px;       /* Fixed height for cells */
+    padding: 0;          /* Padding will be handled by cell-content-wrapper */
+    vertical-align: top;
+    border: 1px solid #ddd; /* Copied from general th, td rule as specific override */
+    /* min-width: 150px; /* No longer needed due to table-layout:fixed and th width setting */
 }
 
-/* General calendar cell min-width */
-.calendar td.calendar-day,
-.calendar td.shift-cell { /* month_view と shift_manager の両方のカレンダーセルを対象とする */
-    min-width: 150px;
-    /* vertical-align: top; や padding: 2px; などは既存のスタイルを維持 */
+.calendar th {
+    /* background: #f9f9f9; /* from general th, td rule */
+    /* border: 1px solid #ddd; /* from general th, td rule */
+    /* padding: 8px; /* from general th, td rule */
+    width: calc(100% / 7); /* Equal width for 7 day columns */
 }
+
 
 table { /* This is a duplicate, ensure it's merged or organized if needed */
     width: 100%;
@@ -190,10 +194,10 @@ ul {
     cursor: pointer;
     /* Adding properties from shift-grid-item for consistency in shift manager grid */
     border: 1px solid #777;
-    word-break: break-all; /* Changed from break-word */
+    word-break: break-all !important; /* Changed from break-word, added !important */
     overflow: hidden; /* Keep hidden to manage overflow with multi-line */
     /* text-overflow: ellipsis; */ /* Removed for multi-line */
-    white-space: normal; /* Added to allow wrapping */
+    white-space: normal !important; /* Added to allow wrapping, added !important */
     /* display: block; is already here, which is fine for grid items taking full cell width if not further styled */
 }
 
@@ -235,6 +239,7 @@ ul {
     word-break: break-word;
     overflow: hidden;
     text-overflow: ellipsis;
+    width: 245px; /* Add - initial estimate for 4.5 buttons */
 }
 
 .btn-xs-custom {
@@ -263,7 +268,8 @@ ul {
     overflow: hidden; /* This was not changed in the previous step for this specific class */
     text-overflow: ellipsis; /* This was not changed in the previous step for this specific class */
     /* white-space: nowrap; /* Might be too restrictive if shift details are longer */
-    min-width: 140px; /* 追加 */
+    /* min-width: 140px; */ /* Remove or comment out */
+    width: 125px; /* Add - initial estimate for 2 buttons */
 }
 
 /* Ensure action buttons in both shift and general events do not shrink and buttons themselves don't wrap */
@@ -320,6 +326,21 @@ ul {
 .event-time {
     font-weight: bold;
     margin-right: 0.3em; /* Space between time and title */
+}
+
+.day-number {
+    font-size: 0.9em;
+    margin-bottom: 2px;
+    font-weight: bold; /* Consolidated from month_view's fw-bold class */
+}
+
+.cell-content-wrapper {
+    width: 100%;
+    height: 100%;
+    overflow-x: auto;
+    overflow-y: auto;
+    padding: 5px;
+    box-sizing: border-box;
 }
 
 .btn-custom-edit {
@@ -392,7 +413,7 @@ ul {
 .user-summary-hitomi { border-color: #0000FF; } /* Vivid Blue */
 .user-summary-sara { border-color: #FFA500; } /* Vivid Orange */
 .user-summary-jun { border-color: #800020; } /* Burgundy */
-.user-summary-nanchan { border-color: #228B22; } /* Khaki */
+.user-summary-nanchan { border-color: #90EE90; } /* Light Green */
 .user-summary-hachi { border-color: #40E0D0; } /* Light Turquoise */
 .user-summary-kie { border-color: #ffd700; } /* Dark Yellow (Amber) */
 .user-summary-gumi { border-color: #C71585; } /* Dark Pink (MediumVioletRed) */
@@ -402,13 +423,15 @@ ul {
 .initial-text-hitomi { color: #0000FF !important; } /* Vivid Blue */
 .initial-text-sara { color: #FFA500 !important; } /* Vivid Orange */
 .initial-text-jun { color: #800020 !important; } /* Burgundy */
-.initial-text-nanchan { color: #228B22 !important; } /* Khaki */
+.initial-text-nanchan { color: #90EE90 !important; } /* Light Green */
 .initial-text-hachi { color: #40E0D0 !important; } /* Light Turquoise */
 .initial-text-kie { color: #ffd700 !important; } /* Gold (consistent with border change) */
 .initial-text-gumi { color: #C71585 !important; } /* Dark Pink (MediumVioletRed) */
 
+/*
 .calendar-scroll-container {
-    overflow-x: auto; /* 水平スクロールを有効化 */
-    overflow-y: auto; /* 垂直スクロールを有効化 */
-    max-height: 75vh; /* ビューポートの高さの75%。この値は調整可能。 */
+    overflow-x: auto;
+    overflow-y: auto;
+    max-height: 75vh;
 }
+*/


### PR DESCRIPTION
あなたのフィードバックに基づき、Calendarioページのレイアウトと表示に関する複数の点を大幅に修正・改善しました。 主な変更点として、カレンダー全体の動的幅調整とスクロールを廃止し、各日付セル内でのコンテンツスクロール方式を導入しました。

変更詳細:
1.  Nanchanさんの色設定変更:
    - 月間サマリー枠線およびシフトイニシャル文字色をライトグリーン(#90EE90)に変更。

2.  シフト管理エリアのテキスト縦書き問題修正:
    - CSSを調整し、シフト管理エリアのイベントテキストが正しく横書きで折り返されるように修正。

3.  メインカレンダービューの予定アイテム固定幅設定:
    - シフト予定アイテムの幅をボタン2つ分に固定。
    - 一般予定アイテムの幅をボタン4.5個分に固定。

4.  カレンダー各日付セル内での縦横スクロール導入:
    - カレンダーテーブルを`table-layout: fixed`とし、各日付セルに固定の幅と高さを設定。
    - 各セル内にラッパーdivを設け、`overflow: auto`を設定することで、セル内容が溢れた場合にセル内でスクロールバーが表示されるように変更。
    - これに伴い、カレンダー全体を覆うスクロールコンテナは削除。