### PR TITLE
Fix: Further UI refinements for calendar and shift views based on fee…

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -207,9 +207,29 @@ ul {
 
 .shift-manager-assignment-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr); /* 4列グリッド */
+    grid-template-columns: repeat(4, minmax(70px, 1fr)); /* Changed from repeat(4, 1fr) */
     gap: 3px; /* アイテム間の隙間 */
     padding-top: 2px; /* 上部のパディング */
+}
+
+/* Adjust display of non-shift events within shift manager */
+.shift-manager-assignment-grid .event-grid-item {
+    grid-column: 1 / -1; /* Span all columns */
+    margin-bottom: 3px; /* Maintain spacing, similar to grid gap */
+    /* width: 313px; is inherited from .event-grid-item */
+    /* Consider justify-self: start; if alignment issues arise */
+}
+
+/* Adjust display of shift items within shift manager */
+.shift-manager-assignment-grid > .assigned {
+    min-width: 70px;          /* Ensure content like "R (4日目)" is visible (kept for robustness) */
+    overflow: hidden;         /* Changed back from visible, now that grid ensures min column width */
+    white-space: nowrap;      /* Ensure text like "R (4日目)" does not wrap */
+    text-overflow: ellipsis;  /* Added for better visual feedback on truncation */
+    height: auto;             /* Ensure height fits content (as per previous changes) */
+    line-height: 1.3;         /* Adjust line height (as per previous changes) */
+    /* This rule is specific to .assigned items within the shift manager grid. */
+    /* It assumes basic styling like background, padding, border might come from a general .assigned or .event-shift-item rule. */
 }
 
 /* For compact calendar event text */


### PR DESCRIPTION
…dback

This commit addresses specific UI issues on the Main Calendar Page and the Shift Edit Page (Admin) as per your feedback, building upon previous an initial UI refinement.

Shift Edit Page (Admin):
- Ensured non-shift events (.event-grid-item) within the shift manager calendar are displayed in a single column (stacked vertically) and maintain a fixed width of approximately 313px. This was achieved by applying `grid-column: 1 / -1;` to these items within the `.shift-manager-assignment-grid`.
- Standardized the width of all event boxes (shift and non-shift) to prevent them from shrinking based on content. Shift items now have a `min-width` of `70px`.
- Corrected the display rule for shifts (initials like R, K, S) to ensure they are displayed in up to 4 columns. Changed the `grid-template-columns` of `.shift-manager-assignment-grid` to `repeat(4, minmax(70px, 1fr))` to guarantee minimum width for each column.
- Resolved the issue where consecutive day indicators (e.g., "(4日目)") were truncated. The `minmax` column definition and `min-width` on shift items, combined with `overflow: hidden` and `text-overflow: ellipsis` on the shift items, ensure the full text is visible if space allows, or gracefully truncated otherwise.

Main Calendar Page:
- Re-verified that shift blocks (.shift-grid-item) are sized to approximately 125px (width of 2 action buttons).
- Re-verified that non-shift event blocks (.event-grid-item) are sized to approximately 313px (width of 5 action buttons).
- Re-verified that non-shift events are displayed as single column items (stacked vertically) within each calendar cell.

These changes aim to improve the consistency, readability, and overall aesthetic of the calendar and shift management interfaces, while minimizing the need for scrollbars.