### PR TITLE
Feat: Finalized calendar UI with fixed widths and cell scrolling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -202,18 +202,18 @@ ul {
     display: block;
     background: #bbdefb;
     margin: 2px 0;
-    padding: 2px 1px; /* Maintained from previous adjustment */
+    padding: 2px 1px !important; /* Padding reverted for shift items */
     border-radius: 4px;
     cursor: pointer;
     border: 1px solid #777;
-    overflow: hidden !important; /* Restored */
-    white-space: nowrap !important; /* Restored */
-    text-overflow: ellipsis !important; /* Restored */
+    overflow: hidden !important; /* Ensured */
+    white-space: nowrap !important; /* Ensured */
+    text-overflow: ellipsis !important; /* Ensured */
     height: auto !important; /* Maintained */
-    line-height: 1.3; /* Maintained */
-    width: 125px !important; /* Restored fixed width */
-    min-width: 125px !important; /* Restored fixed min-width */
-    max-width: 125px !important; /* Restored fixed max-width */
+    line-height: 1.2 !important; /* Adjusted line-height */
+    width: 125px !important; /* Verified fixed width */
+    min-width: 125px !important; /* Verified fixed min-width */
+    max-width: 125px !important; /* Verified fixed max-width */
     box-sizing: border-box; /* Maintained */
     flex-shrink: 0; /* Maintained */
     word-break: normal !important; /* Restored from break-word */
@@ -275,18 +275,19 @@ ul {
 }
 
 .event-grid-item {
-    padding: 2px 4px;
+    padding: 2px 4px !important; /* Adjusted padding and ensured !important */
     border: 1px solid #e0e0e0;
     border-radius: 3px;
     background-color: #f9f9f9; /* Default background */
-    white-space: nowrap !important; /* Restored */
-    word-break: normal !important; /* Restored from break-word */
-    overflow: hidden !important; /* Restored */
-    text-overflow: ellipsis !important; /* Restored */
-    width: 313px !important; /* Restored fixed width */
-    min-width: 313px !important; /* Restored fixed min-width */
-    max-width: 313px !important; /* Restored fixed max-width */
+    white-space: nowrap !important; /* Ensured */
+    word-break: normal !important; /* Ensured */
+    overflow: hidden !important; /* Ensured */
+    text-overflow: ellipsis !important; /* Ensured */
+    width: 200px !important; /* Adjusted width */
+    min-width: 200px !important; /* Adjusted min-width */
+    max-width: 200px !important; /* Adjusted max-width */
     height: auto !important; /* Maintained */
+    line-height: 1.2 !important; /* Adjusted line-height */
     box-sizing: border-box; /* Maintained */
     flex-shrink: 0; /* Maintained */
 }
@@ -310,18 +311,19 @@ ul {
 
 /* Individual shift items within the shift grid */
 .shift-grid-item {
-    padding: 2px 1px; /* Maintained from previous adjustment */
+    padding: 2px 1px !important; /* Padding reverted for shift items */
     border: 1px solid #777; /* Slightly darker border for shift items */
     border-radius: 3px;
     /* background-color and color will be set by .event-shift-item */
-    white-space: nowrap !important; /* Restored */
-    word-break: normal !important; /* Restored from break-word */
-    overflow: hidden !important; /* Restored */
-    text-overflow: ellipsis !important; /* Restored */
-    width: 125px !important; /* Restored fixed width */
-    min-width: 125px !important; /* Restored fixed min-width */
-    max-width: 125px !important; /* Restored fixed max-width */
+    white-space: nowrap !important; /* Ensured */
+    word-break: normal !important; /* Ensured */
+    overflow: hidden !important; /* Ensured */
+    text-overflow: ellipsis !important; /* Ensured */
+    width: 125px !important; /* Verified fixed width */
+    min-width: 125px !important; /* Verified fixed min-width */
+    max-width: 125px !important; /* Verified fixed max-width */
     height: auto !important; /* Maintained */
+    line-height: 1.2 !important; /* Adjusted line-height */
     box-sizing: border-box; /* Maintained */
     flex-shrink: 0; /* Maintained */
 }


### PR DESCRIPTION
This commit culminates a series of detailed UI revisions based on extensive user feedback, establishing a highly specific and robust fixed-width layout for the calendar table, its cells, and all event/shift items. The primary layout strategy involves a fixed-width calendar table, fixed-width cells, and horizontal scrolling within cells if content (like wide event items or multi-column shift displays) exceeds the cell's content area.

Key finalized CSS states:

1.  **Calendar Table (`.calendar`):**
    - Strict `width: 980px !important;`.
    - Centered via `margin: 0 auto;`.
    - `table-layout: fixed;`.

2.  **Calendar Cells (`.calendar th`, `.calendar td`):**
    - Strict `width: 140px !important;` for all cells.
    - `padding: 0;`.

3.  **Cell Content Wrapper (`.cell-content-wrapper`):**
    - `width: 100%;` (of the 140px cell).
    - `padding: 5px;` (content area approx. 130px).
    - `overflow-x: auto;` for horizontal scrolling of content within.

4.  **Overall Calendar Scroll (`.calendar-scroll-container`):**
    - `overflow-x: auto;` for the entire 980px table if viewport is narrower.

5.  **Event Items (`.event-grid-item`):**
    - Strict `width: 200px !important;`.
    - `padding: 2px 4px !important;`.
    - `line-height: 1.2 !important;`.
    - Text overflows with ellipsis if wider than 200px.
    - Scrolls within `.cell-content-wrapper`.

6.  **Shift Items (`.shift-grid-item`, `.assigned`):**
    - Strict `width: 125px !important;`.
    - `padding: 2px 1px !important;` (prioritizing full display of consecutive day info like "R (4日目)").
    - `line-height: 1.2 !important;`.
    - Text overflows with ellipsis if wider than ~121px.
    - These items fit within the cell's content wrapper without scrolling individually, unless part of a wider shift container.

7.  **Shift Display Containers (`.shift-grid-container`, `.shift-manager-assignment-grid`):**
    - `display: grid !important;`
    - `grid-template-columns: repeat(4, 125px) !important;`
    - `gap: 3px !important;`
    - `justify-content: start !important;`
    - This container (approx. 509px wide) scrolls within the `.cell-content-wrapper`.

8.  **HTML (`shift_manager.html`):**
    - Non-shift and shift events remain in separate containers within cells.

This set of changes should provide the precise, compact, and functionally clear calendar display as per your latest detailed requirements.