### PR TITLE
Refactor: Final precision adjustments for event item widths and styles

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -275,7 +275,7 @@ ul {
 }
 
 .event-grid-item {
-    padding: 2px 4px !important; /* Adjusted padding and ensured !important */
+    padding: 2px 4px !important; /* Ensured */
     border: 1px solid #e0e0e0;
     border-radius: 3px;
     background-color: #f9f9f9; /* Default background */
@@ -283,11 +283,12 @@ ul {
     word-break: normal !important; /* Ensured */
     overflow: hidden !important; /* Ensured */
     text-overflow: ellipsis !important; /* Ensured */
-    width: 200px !important; /* Adjusted width */
-    min-width: 200px !important; /* Adjusted min-width */
-    max-width: 200px !important; /* Adjusted max-width */
+    width: 165px !important; /* Adjusted width */
+    min-width: 165px !important; /* Adjusted min-width */
+    max-width: 165px !important; /* Adjusted max-width */
     height: auto !important; /* Maintained */
-    line-height: 1.2 !important; /* Adjusted line-height */
+    line-height: 1.2 !important; /* Ensured */
+    font-size: 0.85em !important; /* Adjusted font size */
     box-sizing: border-box; /* Maintained */
     flex-shrink: 0; /* Maintained */
 }
@@ -331,8 +332,12 @@ ul {
 /* Ensure action buttons in both shift and general events do not shrink and buttons themselves don't wrap */
 .event-grid-item .event-actions,
 .shift-grid-item .event-actions {
-    flex-shrink: 0;
-    white-space: nowrap; /* Ensures buttons stay in a single line */
+    display: flex; /* Added */
+    flex-wrap: nowrap; /* Added (consistent with white-space: nowrap) */
+    justify-content: space-between; /* Added to space out buttons */
+    gap: 2px; /* Added for spacing between buttons */
+    flex-shrink: 0; /* Maintained */
+    white-space: nowrap; /* Maintained: Ensures buttons stay in a single line if flex properties are not fully supported or overridden */
 }
 
 /* Ensure title/text part in both shift and general events truncates properly */


### PR DESCRIPTION
This commit applies final high-precision adjustments to the calendar UI, specifically targeting the width and font-size of `.event-grid-item` and applying flexbox styling to `.event-actions` for better button alignment, as per your latest feedback. This builds upon the established fixed-width (980px table, 140px cells) layout with intra-cell horizontal scrolling.

Key Final Adjustments:

1.  **Event Items (`.event-grid-item`):**
    - Width strictly set to `165px !important;` (reduced from 200px).
    - Font size set to `0.85em !important;`.
    - `padding: 2px 4px !important;` and `line-height: 1.2 !important;` are maintained.
    - These items will scroll within the `.cell-content-wrapper` (approx. 130px content area) as their width (165px) exceeds it.

2.  **Action Button Containers (`.event-actions`):**
    - Applied `display: flex; flex-wrap: nowrap; justify-content: space-between; gap: 2px;` to improve the layout and spacing of action buttons within all event and shift items.

Maintained Structures (from v5/v6):
- Calendar table (`.calendar`) fixed at `980px` width, centered.
- Calendar cells (`th`, `td`) fixed at `140px` width, `padding: 0`.
- Cell content wrapper (`.cell-content-wrapper`) at `width: 100%` (of cell), `padding: 5px`, and `overflow-x: auto`.
- Shift items (`.shift-grid-item`, `.assigned`) remain at `125px` width, `padding: 2px 1px` (for consecutive day text visibility), and `line-height: 1.2`.
- Shift containers (`.shift-grid-container`, etc.) remain as `grid-template-columns: repeat(4, 125px)`.

This commit should achieve the desired compact and precisely aligned UI, reflecting all your specific dimensioning instructions.