### PR TITLE
Here's the proposed change:

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -293,18 +293,20 @@ ul {
     flex-shrink: 0; /* Maintained */
 }
 
-/* Context-specific width for shift events on main calendar, styled as event-grid-item */
-.event-grid-item.event-shift {
+/* Removed .event-grid-item.event-shift rule */
+
+/* New rule for shift events on main calendar with increased specificity */
+div.shift-grid-item.event-grid-item.event-shift {
     width: 125px !important;
     min-width: 125px !important;
     max-width: 125px !important;
-    font-size: 0.85em !important; /* Consistent font size */
-    padding: 2px 4px !important; /* Consistent padding */
-    line-height: 1.2 !important; /* Consistent line-height */
+    padding: 2px 4px !important;
+    font-size: 0.85em !important;
+    line-height: 1.2 !important;
     white-space: nowrap !important;
     overflow: hidden !important;
     text-overflow: ellipsis !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
 }
 
 /* Context-specific width for non-shift events in shift manager */


### PR DESCRIPTION
Fix: Resolve CSS specificity issue for main calendar shift event widths

This update addresses a CSS specificity/ordering issue that prevented the intended `width: 125px` from being applied to shift events on the main calendar views. It also ensures all other context-specific styles and the overall fixed-width layout remain correctly implemented.

Key Changes:

1.  **CSS Selector Specificity (`static/css/style.css`):**
    - The CSS selector for styling shift events on the main calendar (month/week views) has been changed from `.event-grid-item.event-shift` to the more specific `div.shift-grid-item.event-grid-item.event-shift`.
    - This ensures that the styles for these elements (specifically `width: 125px !important;`, `padding: 2px 4px !important;`, `font-size: 0.85em !important;`) correctly override the more general `.event-grid-item` styles.

Maintained Contextual Styles (from v9):
- Default `.event-grid-item` (non-shift, main calendar): `width: 165px !important; font-size: 0.85em !important; padding: 2px 4px !important;`
- `.manager-other-events-container .event-grid-item` (non-shift, shift manager): `width: 160px !important; font-size: 0.85em !important; padding: 2px 4px !important;`
- `.shift-manager-assignment-grid span.assigned.event-grid-item.event-shift` (shift, shift manager): `width: 125px !important; font-size: 0.9em !important; padding: 2px 1px !important;`

Maintained Overall Layout Structure (from v8):
- Calendar table fixed at `980px` width, cells at `140px`.
- `.cell-content-wrapper` provides horizontal scrolling for oversized content.
- HTML class attributes for shift events are correctly in place.

This update should definitively resolve the width rendering issue for shift items on the main calendar, ensuring all elements are displayed according to the precise, context-aware specifications you provided.