### PR TITLE
Fix: Override .d-flex for main calendar shifts to ensure fixed width

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -537,3 +537,28 @@ div.shift-grid-item.event-grid-item.event-shift {
     box-sizing: border-box !important;
     flex: 0 0 125px !important; /* Added flex property */
 }
+
+/* ---- FINAL override for *only* shift items on month/week view ---- */
+div.shift-grid-item.event-grid-item.event-shift {
+    /* ❶ フレックス挙動を完全停止 */
+    display: block !important;      /* d-flex を打ち消す */
+    flex: none !important;          /* flex:0 0 auto 相当 */
+
+    /* ❷ 幅をボタン 2 個分に固定   */
+    width: 135px !important;        /* ← ボタン×2 + 余白ピッタリ */
+    min-width: 135px !important;
+    max-width: 135px !important;
+
+    /* ❸ 文字がはみ出ても箱は伸びない */
+    overflow: hidden !important;
+    white-space: nowrap !important;
+    text-overflow: ellipsis !important;
+    box-sizing: border-box !important;
+
+    /* ❹ 他の .event-grid-item と共通のスタイルを適用 */
+    padding: 2px 4px !important;
+    font-size: 0.85em !important;
+    line-height: 1.2 !important;
+    background-color: gray !important; /* Ensure shift appearance */
+    color: white !important;       /* Ensure shift text color */
+}


### PR DESCRIPTION
This commit applies a final CSS patch to definitively resolve the issue of main calendar shift blocks not adhering to their specified width due to Bootstrap's .d-flex utility and CSS precedence/specificity conflicts.

The core of this fix is a highly specific CSS rule for main calendar shift events, placed at the end of `style.css` to ensure it takes ultimate precedence.

Key Changes:

1.  **Main Calendar Shift Event Override (`static/css/style.css`):**
    - I added a new rule for `div.shift-grid-item.event-grid-item.event-shift` to the end of the stylesheet with the following critical properties: - `display: block !important;` (Overrides `.d-flex`) - `flex: none !important;` (Prevents any flex item behavior) - `width: 135px !important;` (Strict width for 2 buttons) - `min-width: 135px !important;` - `max-width: 135px !important;` - `padding: 2px 4px !important;` - `font-size: 0.85em !important;` - `line-height: 1.2 !important;` - `background-color: gray !important;` - `color: white !important;` - Standard text overflow and box-sizing properties.
    - This change means shift events on the main calendar will now stack vertically (as blocks) within their parent `.shift-grid-container`, rather than attempting a multi-column flex layout.

Maintained Contextual Styles (from v12):
- Default `.event-grid-item` (non-shift, main calendar): `width: 165px !important;`
- `.manager-other-events-container .event-grid-item` (non-shift, shift manager): `width: 160px !important;`
- `.shift-manager-assignment-grid span.assigned.event-grid-item.event-shift` (shift, shift manager): `flex: 0 0 125px !important; width: 125px !important; padding: 2px 1px !important;` (maintaining 4-column grid layout and specific padding for consecutive days).

Maintained Overall Layout Structure (from v8):
- Calendar table fixed at `980px` width, cells at `140px`.
- `.cell-content-wrapper` provides horizontal scrolling for oversized content.

This commit should finally achieve the precise width control for all event types across all calendar views as per your exhaustive feedback.