### PR TITLE
Fix: Restore individual initial colors for shift events

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -321,7 +321,7 @@ ul {
     font-size: 0.85em !important; /* Default font size for shifts */
     padding: 2px 4px !important;   /* Default padding for shifts (e.g., main calendar) */
     background-color: gray !important; /* Shift-specific appearance */
-    color: white !important;           /* Shift-specific appearance */
+    /* color: white !important; /* Removed as per subtask - color should be from initial-text-* or event-shift-item */
     /* Inherits line-height, text handling etc. from base .event-grid-item */
     /* Note: .shift-grid-item also gets these properties by having .event-grid-item.event-shift classes */
     /* Note: .assigned items in manager also get these by having .event-grid-item.event-shift classes */


### PR DESCRIPTION
This commit resolves an issue where shift event initials were all displayed in white, overriding their intended individual colors. The `color: white !important;` declaration has been removed from the `.event-grid-item.event-shift` CSS rule, allowing the more specific `.initial-text-...` class rules to correctly apply the text color for employee initials.

Key Changes:

1.  **CSS Modification (`static/css/style.css`):**
    - Removed `color: white !important;` from the `.event-grid-item.event-shift` rule.
    - Other properties of this rule, such as `background-color: gray !important;`, `flex: 0 0 125px !important;`, `width: 125px !important;`, `font-size: 0.85em !important;`, and `padding: 2px 4px !important;`, are maintained.

Maintained Styles (Unaffected by this specific change):
- All styles for non-shift events (`.event-grid-item:not(.event-shift)` and its context-specific overrides).
- Specific styles for shift items in the shift manager page, including `padding: 2px 1px !important;` and `font-size: 0.9em !important;` for `.shift-manager-assignment-grid span.assigned.event-grid-item.event-shift`.
- The overall fixed-width calendar layout (980px table, 140px cells), intra-cell horizontal scrolling (`.cell-content-wrapper`), and full-table scrolling (`.calendar-scroll-container`).

This targeted fix ensures that shift events are visually distinguishable by their user-specific initial colors while retaining all other aspects of the established UI design.