### PR TITLE
Fix: Correct import statement capitalization for Seminario module

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,7 +51,7 @@ def create_app() -> "Flask":
     from .invites import bp as invites_bp
     from .calendario import bp as calendario_bp
     from .resoconto import bp as resoconto_bp
-    from .seminario import bp as seminario_bp
+    from .Seminario import bp as seminario_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(punto_bp)

--- a/run.py
+++ b/run.py
@@ -12,12 +12,12 @@ from app.resoconto import utils as resoconto_utils
 from app.resoconto import tasks as resoconto_tasks
 from app.resoconto.tasks import start_scheduler
 from app.intrattenimento.tasks import start_scheduler as start_intrattenimento_scheduler
-from app.seminario.tasks import start_scheduler as start_seminario_scheduler
+from app.Seminario.tasks import start_scheduler as start_seminario_scheduler
 from app.principessina.tasks import start_scheduler as start_principessina_scheduler
 from app.corso.tasks import start_scheduler as start_corso_scheduler
 from app.principessina import utils as principessina_utils
 from app.quest_box import utils as quest_utils
-from app.seminario import utils as seminario_utils
+from app.Seminario import utils as seminario_utils
 from app.bravissimo import utils as bravissimo_utils
 from app.scatola_capriccio import utils as scatola_capriccio_utils
 from app.monsignore import utils as monsignore_utils


### PR DESCRIPTION
I corrected the import statements for the 'Seminario' module in `run.py` and `app/__init__.py` to use the proper capitalization ('Seminario' instead of 'seminario').

This change addresses potential `ModuleNotFoundError` errors in case-sensitive file system environments (e.g., Linux) where Python's import system would fail to locate the module due to the mismatch between the imported name and the actual directory name (`app/Seminario`).

Changes made:
- In `run.py`:
    - `from app.seminario.tasks ...` changed to `from app.Seminario.tasks ...`
    - `from app.seminario import utils ...` changed to `from app.Seminario import utils ...`
- In `app/__init__.py`:
    - `from .seminario import bp ...` changed to `from .Seminario import bp ...`