### PR TITLE
Refactor: Enable Flask application startup via `flask run` in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -24,6 +24,9 @@ from app.monsignore import utils as monsignore_utils
 from app.calendario import utils as calendario_utils
 from app.invites import utils as invite_utils
 
+from app import create_app
+
+app = create_app()
 
 def display_menu(user: Dict[str, str]):
     while True:


### PR DESCRIPTION
I've modified `run.py` to allow the Flask application to be started using the `flask run` command, in addition to its existing CLI functionality.

Changes:
- Imported the `create_app` factory function from the `app` package.
- Created a Flask application instance named `app` at the module level by calling `create_app()`. This `app` instance is now discoverable by the Flask CLI.
- The existing `main()` function, which launches the custom command-line interface, is preserved and continues to be executed when `run.py` is run directly (i.e., `if __name__ == "__main__":`).

This allows you to use `FLASK_APP=run.py flask run` (or rely on auto-detection of `app` in `run.py`) to start the Flask development server, while `python run.py` will still launch the CLI menu as before.