### PR TITLE
feat(calendario): Add new event genres, specialized schedules, and im…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,133 +1,226 @@
-# Famigliapp CLI プロトタイプ
+# Famigliapp: Your Private Family & Community Hub
 
-## 開発状況まとめ
-現在はCLIとFlask Web版の双方でポイント管理・各掲示板・カレンダー・タスク管理等の主要機能が動作します。
-メールに加えLINE NotifyやPushbulletでの通知、AI解析付きResocontoレポートなども実装済みです。
-スケジューラーによるリマインダーやドラッグ&ドロップ対応のシフト管理など、仕様で挙げられた機能の大部分が実装されました。
+**Famigliapp** is a versatile, private application designed to foster connection, organization, and fun within families or small communities. It combines practical tools with engaging features to manage daily life and strengthen bonds.
 
+## Overview
 
-Famigliapp は家族専用のコミュニティアプリを目指したプロジェクトの CLI 版プロトタイプです。Web アプリの前段階として作られており、ユーザーごとのポイント管理や簡易掲示板などの機能をコマンドラインから試すことができます。
+Famigliapp serves as a central digital space for family members or a close-knit group. It offers a suite of tools ranging from shared calendars and task management to unique point systems and various themed bulletin boards for different types of interaction. Initially prototyped as a CLI application, it has evolved to include a Flask-based web interface, offering a richer user experience. The application supports notifications via email, LINE Notify, and Pushbullet, and even incorporates AI for analyzing work reports.
 
-## 実行方法
+## Current Development Status
 
-Python 3 がインストールされている環境で、次のコマンドを実行します。
+The application includes a wide array of functional modules, accessible via both a command-line interface (CLI) and a Flask web application. Key features such as point management, diverse bulletin boards (for general posts, audio praise, feedback, media sharing), shared calendar with shift management, task management (Quest Box), and various reporting/utility functions are implemented. The system uses a hybrid data storage approach with JSON files for many features and SQLAlchemy for core user data. Notification systems and AI integration for text analysis are also in place.
 
-```
+## Key Features
+
+Famigliapp is composed of several distinct modules, each catering to different needs:
+
+*   **User Authentication:** Secure login system with predefined user accounts and roles (admin, user). Passwords are not stored in plain text (implied by standard Flask practices, though not explicitly detailed in provided files).
+*   **Punto (Points System):**
+    *   Manages user points: `AhvPunto` (A points), `OzePunto` (O points), and `UnitoPunto` (A - O, auto-calculated).
+    *   Admin can edit points. Users can view their own points.
+    *   Point changes trigger email notifications.
+    *   Features include point history, rankings (weekly, monthly, yearly, all-time, growth rate), and graph visualization.
+    *   Data primarily stored in `points.json` and `points_history.json`.
+*   **Posts (Generic Bulletin Board):**
+    *   General purpose posting and viewing.
+    *   Supports categories, author filtering, keyword search, and date range filtering.
+    *   Users can edit their own posts; admins can edit/delete any post.
+    *   Supports comments on posts.
+    *   Data stored in `posts.json` and `comments.json`.
+*   **Bravissimo! (Audio Praise Board):**
+    *   Admins can upload audio praise messages directed at specific users.
+    *   Targeted users receive notifications.
+    *   Allows searching by date, sender, and recipient.
+    *   All users can listen and save audio files.
+    *   Data and uploaded files managed by the `bravissimo` module.
+*   **Intrattenimento (Entertainment Sharing):**
+    *   Users share thoughts and media (audio/video) on entertainment.
+    *   Supports titles, body text, optional file uploads, and an expiration date for posts.
+    *   Features filtering by author, keyword, and date range.
+    *   Expired posts are hidden from regular users but accessible to admins.
+    *   Includes a daily reminder (8 PM) for users who haven't posted.
+    *   Data in `intrattenimento.json`, uploads in `static/uploads`.
+*   **Corso (Course/Seminar Feedback):**
+    *   Platform for users to post feedback on courses or seminars they've attended.
+    *   Supports file uploads (e.g., seminar materials, audio/video).
+    *   Features filtering by author and keyword search.
+    *   Posts can have an expiration date, after which they are hidden from regular users but retained for admins.
+    *   Data in `corso.json`, uploads in `static/uploads`.
+*   **Seminario (Lesson Feedback & Scheduling):**
+    *   Users post feedback on lessons/tutoring sessions.
+    *   Users can register lesson dates; receives daily reminders to post feedback for past, un-commented lessons.
+    *   Supports filtering by author and keyword.
+    *   Data in `seminario.json`.
+*   **Principessina (Baby Reports):**
+    *   Primarily for babysitters/staff to report on a child's status.
+    *   Supports text, image, and video uploads.
+    *   All users can view; features filtering by poster and keyword.
+    *   Includes a daily reminder for all users to post.
+    *   Data in `principessina.json`, media likely in `static/uploads`.
+*   **Monsignore (Image-based Column/Feedback):**
+    *   Users and admins can upload images (e.g., columns, articles).
+    *   Users can post comments/feedback on these images.
+    *   Supports filtering by upload date and keyword search.
+    *   Includes a daily reminder to post feedback on un-commented images.
+    *   Data in `monsignore.json`, uploads in `static/uploads`.
+*   **Scatola di Capriccio (Feedback & Survey Box):**
+    *   Users can submit feedback and suggestions.
+    *   Content is visible only to administrators.
+    *   Admins can post surveys targeted at specific users, triggering notifications.
+    *   Data in `scatola_capriccio.json` and `scatola_surveys.json`.
+*   **Quest Box (Task Management):**
+    *   Users and admins can post tasks or requests.
+    *   Admins can define participation conditions, deadlines, and rewards (A-points or monetary).
+    *   Tasks can be assigned to specific users or open for acceptance.
+    *   Users can accept quests, report progress, and mark as complete (requiring confirmation from the issuer).
+    *   Data in `quests.json`.
+*   **Vote Box (Voting/Polls):**
+    *   Allows users to create and participate in polls.
+    *   Features include creating votes, viewing open/closed votes, and seeing vote details.
+    *   Data likely in `votebox.json`.
+*   **Nedari Box (Requests/Begging):**
+    *   A space for users to make requests for items or favors.
+    *   Data likely in `nedari.json`.
+*   **Calendario (Shared Calendar & Shift Management):**
+    *   Shared calendar for events. Users can add, edit (own), and view events.
+    *   Event modifications trigger notifications to all users.
+    *   **Shift Management (Admin only):**
+        *   Visual drag-and-drop interface for assigning employees to shifts.
+        *   Warnings for rule violations (max consecutive workdays, min staff per day, forbidden/required pairings, attribute requirements).
+        *   Employee attributes (A, B, C, D) can be defined for rule-based warnings.
+        *   Displays ongoing work/off day counts for employees.
+        *   Calendar statistics (work/off days per employee) viewable.
+    *   Data in `events.json` and `calendar_rules.json`.
+*   **Resoconto (Work Reports & AI Analysis):**
+    *   Users submit daily work reports.
+    *   Reports are processed daily (4 AM) by an AI (Claude API) to generate summaries, rankings, and critiques visible to admins.
+    *   Admins can view all reports and AI analysis; users can view their own.
+    *   Features report counts ranking and CSV export.
+    *   Data in `resoconto.json`.
+*   **Invite System:**
+    *   Admins can generate invite codes for new users to join.
+    *   Data in `invites.json`.
+*   **Notification System:**
+    *   Core events (point changes, new posts in some modules, calendar edits) trigger notifications.
+    *   Supports Email, LINE Notify, and Pushbullet.
+    *   Configuration in `config.py`.
+
+## Technology Stack
+
+*   **Backend:** Python, Flask
+*   **Database:** Primarily JSON files for most features. SQLAlchemy and SQLite are used for core models like User, Post, and PointsHistory (see `app/models.py`). Alembic is used for SQLAlchemy database migrations.
+*   **Frontend:** Jinja2 for templating, HTML, CSS, JavaScript.
+*   **Forms:** Flask-WTF for web forms.
+*   **Scheduling:** APScheduler for reminder tasks and daily report processing.
+*   **AI Integration:** Anthropic Claude API for Resoconto analysis (requires API key).
+*   **Notifications:** Email (Flask-Mail), LINE Notify, Pushbullet.
+*   **Development Server:** Werkzeug (via `flask run`).
+
+## Directory Structure and Key File Roles
+
+*   **`run.py`**: Main entry point for the CLI application and for launching the Flask web server via `flask run`.
+*   **`config.py`**: Contains application configuration, including user credentials, file paths for JSON data, API keys, and notification settings.
+*   **`requirements.txt`**: Lists Python package dependencies.
+*   **`app/`**: Main application package.
+    *   **`__init__.py`**: Application factory (`create_app`), initializes Flask extensions, registers blueprints.
+    *   **`models.py`**: Defines SQLAlchemy database models (User, Post, PointsHistory).
+    *   **`utils.py`**: General utility functions for the application.
+    *   **`<module_name>/` (e.g., `app/punto/`, `app/calendario/`)**: Individual feature modules (blueprints). Typically contain:
+        *   `__init__.py`: Blueprint registration.
+        *   `routes.py`: Defines web routes and view functions for the module.
+        *   `forms.py`: Defines WTForms for web input.
+        *   `utils.py`: Module-specific utility functions and data handling (often interacting with JSON files).
+        *   `tasks.py`: Module-specific scheduled tasks (if any).
+        *   `templates/<module_name>/`: Jinja2 templates for the module's web pages.
+*   **`static/`**: Static files (CSS, JavaScript, images, user uploads).
+*   **`migrations/`**: Alembic database migration scripts for SQLAlchemy models.
+*   **Data Files (`*.json`)**: Located in the project's root directory, storing data for various features (e.g., `points.json`, `events.json`). These are typically created automatically on first use.
+
+## Setup and Execution
+
+### Prerequisites
+
+*   Python 3 (e.g., 3.8+)
+*   `pip` (Python package installer)
+
+### Installation
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository_url>
+    cd <repository_name>
+    ```
+2.  **Create and activate a virtual environment (recommended):**
+    ```bash
+    python -m venv venv
+    # On macOS/Linux:
+    source venv/bin/activate
+    # On Windows:
+    # venv\Scripts\activate
+    ```
+3.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+### Configuration
+
+1.  Review `config.py`.
+2.  **`USERS`**: Define user accounts, passwords, roles, and emails in the `USERS` dictionary.
+3.  **`SECRET_KEY`**: Change this to a strong, unique random string for session management in a production-like environment.
+4.  **API Keys & Tokens (Optional):**
+    *   `LINE_NOTIFY_TOKEN`: For LINE notifications.
+    *   `PUSHBULLET_TOKEN`: For Pushbullet notifications.
+    *   `ANTHROPIC_API_KEY` (or ensure the relevant environment variable is set for Claude API access, as used in `resoconto/tasks.py`).
+5.  **Mail Settings (Optional):**
+    *   Set `MAIL_ENABLED = True` to enable email notifications.
+    *   Configure `MAIL_SERVER`, `MAIL_PORT`, `MAIL_SENDER`, and potentially `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_USE_TLS`, `MAIL_USE_SSL` depending on your email provider.
+
+### Database Setup
+
+*   **SQLAlchemy Database (User, Post, PointsHistory):**
+    The application uses Flask-Migrate for database schema migrations. Ensure `FLASK_APP=run.py` is set in your environment.
+    ```bash
+    # Initialize migrations directory (only if it doesn't exist)
+    # flask db init
+
+    # Generate a new migration script after changes to SQLAlchemy models in app/models.py
+    # flask db migrate -m "Brief description of model changes"
+
+    # Apply the latest migrations to the database (creates or updates tables)
+    flask db upgrade
+    ```
+    A SQLite database file (`famigliapp.db`) will be created in the project root by default.
+*   **JSON Data Files:** Most other data (points, module-specific posts, calendar events, etc.) are stored in JSON files (e.g., `points.json`, `events.json`) in the project root. These are generally created automatically when features are first used.
+
+### Running the Application
+
+**1. Command-Line Interface (CLI):**
+```bash
 python run.py
 ```
+You will be prompted for your username and password.
 
-起動後にユーザー名とパスワードを入力するとメニューが表示されます。メニュー項目は次の通りです。
-
-1. **ポイントを見る** ― 各ユーザーのポイント(A/O/U)を確認します。
-2. **ポイントを編集する** ― 管理者のみ利用可能。任意ユーザーのポイントを変更します。
-3. **投稿を見る** ― 投稿一覧を表示します。カテゴリや投稿者、キーワードによる絞り込みが可能です。
-4. **投稿する** ― 新しい投稿を追加します。
-5. **投稿を削除する** ― 管理者のみ利用可能。ID を指定して投稿を削除します。
-6. **ランキングを見る** ― A・O・U のいずれかのポイントでランキングを表示します。期間は全期間のほか、週間・月間・年間を選択できます。
-7. **ポイント履歴を見る** ― ポイント変動履歴を期間やユーザー名で確認します。
-8. **投稿を編集する** ― 投稿者本人または管理者が内容を変更します。
-9. **intrattenimento を見る** ― intrattenimento掲示板の投稿一覧を表示します。投稿者やキーワードに加え、開始日・終了日でも絞り込み可能です。
-10. **intrattenimento に投稿する** ― 新しい intrattenimento 投稿を追加します。タイトル、本文、公開終了日を入力します。
-11. **intrattenimento 投稿を削除する** ― 管理者のみ利用可能。ID を指定して intrattenimento 投稿を削除します。
-12. **Corso を見る** ― Corso 掲示板の投稿を表示します。
-13. **Corso に投稿する** ― 新しい Corso 投稿を追加します。
-14. **履歴をCSV出力** ― ポイント履歴をCSV形式で保存します。
-15. **Resoconto を見る** ― 業務報告一覧を表示します。
-16. **Resoconto に投稿する** ― 新しい業務報告を追加します。
-17. **Resoconto ランキングを見る** ― ユーザー別の報告数ランキングを表示します。
-18. **Principessina を見る** ― ベイビー報告の一覧を表示します。
-19. **Principessina に投稿する** ― 新しいベイビー報告を追加します。
-20. **Quest一覧を見る** ― 登録されたQuestを一覧表示します。期限が設定されている場合は `(期限: YYYY-MM-DD)` と併せて表示されます。
-21. **Questを投稿する** ― 新しいQuestを作成します。期限は `YYYY-MM-DD` 形式で入力します。設定した期限は Quest の一覧画面や詳細画面で確認でき、CLI の一覧表示でも `(期限: YYYY-MM-DD)` として表示されます。
-22. **QuestをAcceptする** ― 指定したQuestを引き受けます。
-23. **Questを完了する** ― Accept済みのQuestを完了扱いにします。
-24. **Questを削除する** ― 管理者のみ利用可能。IDを指定してQuestを削除します。
-25. **Quest報酬を設定する** ― 管理者が報酬を登録します。
-26. Seminario一覧を見る
-27. Seminarioをスケジュールする
-28. Seminarioにフィードバックする
-29. Bravissimo を見る
-30. Bravissimo に投稿する (管理者のみ)
-31. Bravissimo 投稿を削除する (管理者のみ)
-32. Scatola Capriccio を見る (管理者のみ)
-33. Scatola Capriccio に投稿する
-34. Monsignore を見る
-35. Monsignore に投稿する
-36. Monsignore 投稿を削除する (管理者のみ)
-37. カレンダーを見る
-38. カレンダーにイベント追加
-39. カレンダーのイベント削除 (管理者のみ)
-40. カレンダーのイベント移動
-41. カレンダーの担当者割当
-42. カレンダールールを見る (管理者のみ)
-43. カレンダールールを編集する (管理者のみ、禁止組み合わせや属性条件も設定可能)
-44. Questを編集する (管理者のみ)
-45. ResocontoをCSV出力 (管理者のみ)
-46. カレンダー統計を見る
-47. ポイント推移サマリを見る
-48. Scatola Capriccio アンケートを見る (管理者のみ)
-49. Scatola Capriccio アンケートを投稿 (管理者のみ)
-50. 上昇率ランキングを見る
-51. 投稿にコメントする
-52. Resoconto AI分析を見る (管理者のみ)
-
-Web 版では各コメントの作者または管理者が編集できるリンクも表示されます。
-0. **終了** ― アプリを終了します。
-
-### 投稿のフィルタ
-
-「投稿を見る」を選択すると、カテゴリ、投稿者、検索語に加えて開始日と終了日を入力して一覧を絞り込めます。空欄の項目は無視されるため、複数条件を組み合わせた検索も可能です。検索語は大文字小文字を区別せずに一致判定されます。
-
-## ユーザーとパスワード
-
-利用できるアカウント情報は `config.py` の `USERS` 辞書にまとめられています。必要に応じて追加や変更を行ってください。Web 版でセッション管理に使用する `SECRET_KEY` も同ファイル内で設定できます。公開リポジトリにアップロードする場合は適切な値へ変更することを推奨します。
-
-## データファイル
-
-ポイント情報は `points.json`、投稿情報は `posts.json` としてプロジェクトのルートディレクトリに保存されます。初回実行時に自動生成され、アプリの操作内容に応じて更新されます。
-
-## 通知設定
-
-`config.py` の `LINE_NOTIFY_TOKEN` にトークンを設定すると、メール送信に加えて LINE Notify へも同じ内容が送信されます。空のままの場合は LINE への通知は行われません。
-同様に `PUSHBULLET_TOKEN` を設定すると Pushbullet 経由でスマホや PC へ直接通知を送れます。
-
-## Web 版の起動方法
-
-Flask を使った簡易 Web 版を起動する場合は以下の手順を実行します。
-
+**2. Web Application (for development):**
+Ensure your `FLASK_APP` environment variable is set:
 ```bash
-pip install -r requirements.txt
-export FLASK_APP=app
+# On macOS/Linux:
+export FLASK_APP=run.py
+# On Windows (Command Prompt):
+# set FLASK_APP=run.py
+# On Windows (PowerShell):
+# $env:FLASK_APP = "run.py"
+
 flask run
 ```
+The application will typically be available at `http://127.0.0.1:5000/`. For production, use a proper WSGI server like Gunicorn or uWSGI.
 
-コマンドを実行すると `http://127.0.0.1:5000/` でアクセスできるようになります。
+## Data Management
 
-ログイン後、トップページにはポイント管理用の
-"Punto ダッシュボード" へのリンクが表示され、`/punto` から利用できます。
-ランキングは `/punto/rankings` で閲覧可能です。指標(A/O/U)と期間を選択して表示できます。
-ポイント履歴は `/punto/history` から確認できます。ユーザー名と日付でフィルタリング可能です。
-履歴をグラフ表示する `/punto/graph` と、CSV をダウンロードする `/punto/history/export` も利用できます(後者は管理者のみ)。
+Famigliapp uses a hybrid data storage approach:
+*   **SQLAlchemy (SQLite by default):** Manages core, structured data like user accounts, generic posts, and point transaction history. This provides relational integrity for these key entities.
+*   **JSON Files:** Feature-specific data for most modules (e.g., balances in `points.json`, individual module posts, calendar events, configurations) are stored in separate JSON files in the project root. This approach was likely chosen for simplicity during rapid prototyping and ease of inspection.
 
-掲示板は `/posts` から利用できます。カテゴリ、投稿者、キーワードのほか開始日・終了日を指定して一覧を絞り込み、新規投稿は `/posts/add` で行います。管理者は各投稿の "削除" リンクから投稿を削除できます。
+## License
 
-ブラヴィッシモ(褒め言葉掲示板)は `/bravissimo` で閲覧できます。管理者のみ `/bravissimo/add` から投稿可能です。投稿時に対象ユーザーを指定すると、そのユーザーへメール通知が送られます。一覧画面では投稿者・対象ユーザー・キーワードで絞り込みができます。
-
-インタッテニメント掲示板は `/intrattenimento` から利用できます。タイトルと本文、公開終了日、添付ファイルを入力して投稿できます。一覧画面では投稿者・キーワードのほか開始日と終了日で絞り込みが可能です。一般ユーザーは公開期間を過ぎた投稿を閲覧できません。
-CLI を起動すると、毎日20時に投稿がないユーザーへリマインドメールを送るスケジューラーも起動します。
-レッツィオーネのフィードバックが未提出の場合は、受講日を過ぎたエントリーに対し毎朝9時に通知するスケジューラーも動作します。
-Corso 掲示板は `/corso` から利用できます。タイトル、本文、公開終了日、添付ファイルを指定して投稿し、管理者は削除も行えます。
-
-スカトラ・ディ・カプリッチョ(フィードバック用掲示板)は `/scatola_capriccio` で閲覧できます。一般ユーザーは `/scatola_capriccio/add` からフィードバックを投稿でき、投稿内容は管理者のみ閲覧可能です。
-
-共有カレンダー機能は `/calendario` から利用します。日付とタイトル、内容を入力してイベントを登録できます。管理者は各イベントの "削除" リンクから予定を削除可能です。勤務日数・休日数を集計表示する `/calendario/stats` ページもあり、開始日と終了日を指定して統計を確認できます。イベントの追加・編集・削除が行われると、内容が全ユーザーにメール通知されます。
-業務報告ページ "Resoconto" は `/resoconto` からアクセスできます。ユーザーは日付と内容を入力して報告を投稿できます。管理者は全ユーザーの報告一覧を閲覧し、不要な投稿を削除できます。
-報告数のランキングは `/resoconto/rankings` で確認できます。期間を指定して集計することも可能です。
-管理者専用の `/resoconto/analysis` では、投稿内容を AI 解析した結果を閲覧できます。
-ベイビー報告 "Principessina" は `/principessina` から利用できます。文章と添付ファイルを投稿でき、管理者は削除も行えます。
-CLI 起動時には、当日の投稿がないユーザーへ毎晩 21 時にリマインドメールを送るスケジューラーも自動で開始されます。
-
-
-## ライセンス
-
-このプロジェクトは MIT License のもとで公開されています。詳しくは LICENSE ファイルを参照してください。
+This project is licensed under the MIT License. See the `LICENSE` file for details.

--- a/TODO.md
+++ b/TODO.md
@@ -1,22 +1,78 @@
-# 残作業メモ
-現在のリポジトリでは掲示板、カレンダー、ポイント管理など仕様の大半が実装済みです。
-今後は細かなバリデーション追加やテスト強化が課題となっています。
+# Famigliapp TODO List
 
+## Introduction
 
-以下は `about this app.txt` と `README.md` を確認した上で、
-現状のコードベースに未実装または改善が必要と思われる点をまとめたものです。
+This document outlines pending tasks, unimplemented features based on original specifications, and potential areas for enhancement for the Famigliapp application. The application is currently in a mature prototype stage with many core features implemented for both CLI and Web interfaces. This list aims to guide further development towards a more robust and feature-complete state.
 
-## 未実装機能
+## Unimplemented or Partially Implemented Specifications/Features
 
-- ~~LINE などメール以外の通知手段への対応~~ (LINE Notify を実装済み)
-- ~~Resoconto の AI 分析とランキング生成~~ (実装済み、仕様では毎日4時に集計)
-- ~~カレンダー画面でのドラッグ＆ドロップによるシフト編集~~ (実装済み)
-- ~~勤務日数/休日数をカレンダー一覧ページで表示~~ (実装済み)
+This section lists items derived from the `about this app.txt` specification document that appear to be not yet fully implemented or require clarification and potential further development.
 
-## 改善候補
+*   **Scatola di Capriccio (Feedback & Survey Box):**
+    *   Clarify and potentially implement user-to-user feedback if originally intended (current model seems user-to-admin for feedback).
+    *   Enhance UI/UX for admin survey creation, target user selection, and management of responses.
+    *   Review notification system for surveys to ensure it aligns with "全員に通知" (notify all targeted users) if complex targeting is used.
+*   **Quest Box (Task Management):**
+    *   Develop a more detailed UI for managing the full lifecycle: progress reporting by assignees, and confirmation of completion by issuers.
+    *   Implement specific logic and tracking for "cash reward" handling beyond just a text field (e.g., logging payouts, status).
+*   **File Uploads (Corso, Seminario, Monsignore, Intrattenimento, Principessina):**
+    *   While uploads are supported, implement robust handling for video files: size limits, format validation, potential for streaming vs. direct download, thumbnail generation.
+    *   Ensure consistent file management across modules (storage, deletion).
+*   **Daily Reminders (Corso, Seminario, Monsignore, Intrattenimento, Principessina):**
+    *   Verify the robustness and accuracy of daily reminder notifications (e.g., "until feedback is posted"). Ensure tasks are correctly tracking status and triggering reminders appropriately for all specified modules.
+    *   Consider user-configurable reminder preferences (e.g., opt-out for certain modules).
+*   **Calendario (Shared Calendar & Shift Management):**
+    *   Review notification granularity: `about this app.txt` implies "編集が行われるたびに編集者と、編集内容が全員に通知される" (every edit, with details, to everyone). Ensure current notifications match this detail or enhance if they are summary-based.
+    *   Enhance the UI for displaying shift rule warnings to make them more prominent and actionable for admins during shift planning.
+*   **Resoconto (Work Reports & AI Analysis):**
+    *   Develop a dedicated admin interface/workflow for reviewing AI analysis and efficiently allocating points based on it. Current point allocation is manual and separate.
+*   **Invite System:**
+    *   Clarify and potentially implement the workflow for how new users utilize invite codes for registration/first login if this is not fully fleshed out in the web version.
 
-- ~~Web 版でのコメント編集機能追加~~ (実装済み)
-- 各掲示板へのファイル添付の制限やバリデーション強化
-- コード全体のテスト追加・カバレッジ向上
+## Enhancements for Existing Features
 
-上記を実装することで、仕様に近い形での完成度を高められる見込みです。
+*   **General File Attachments:**
+    *   Implement security scanning/sanitization for all uploaded files.
+    *   Develop preview capabilities for common file types directly in the web UI.
+*   **Notification System:**
+    *   Provide user-level settings to configure notification preferences (e.g., choose delivery channels, opt-out of certain non-critical notifications).
+    *   Improve content and formatting of notification messages for clarity.
+*   **Punto (Points System):**
+    *   Full integration of Quest Box rewards (A-points) into the Punto system.
+    *   Consider more detailed logging or categories for point consumption/earning if needed for advanced auditing.
+*   **UI/UX (Web Version):**
+    *   Unify design language and user experience across all modules.
+    *   Improve mobile-friendliness and responsiveness.
+    *   Enhance CLI usability with clearer prompts, more consistent output formatting.
+*   **Search Functionality:**
+    *   Explore options for a global, cross-module search feature.
+    *   Improve search accuracy and relevance ranking.
+*   **Admin Panel/Dashboard:**
+    *   Develop a centralized web-based admin panel for managing users (beyond `config.py`), viewing system logs, managing data across modules (e.g., bulk operations), and application settings.
+
+## Bug Fixes & Stability
+
+*   **Error Handling:** Conduct a comprehensive review of error handling across both CLI and web components, especially for file I/O, API interactions, and data parsing.
+*   **JSON File Performance:** For modules with potentially large JSON files (e.g., posts, history), investigate and implement strategies to mitigate performance degradation (e.g., data archiving, pagination for reads, more efficient writes).
+*   **Input Validation:** Strengthen input validation across all forms (CLI and Web) to prevent errors and potential security issues.
+*   **Concurrency:** Review and test behavior if multiple users/processes attempt to write to the same JSON file simultaneously (though less of an issue with Flask's typical single-worker dev server, important for production).
+
+## Testing
+
+*   **Unit Tests:** Increase unit test coverage for utility functions, business logic in each module, and data handling functions.
+*   **Integration Tests:** Develop more integration tests for interactions between different modules (e.g., Quest rewards affecting Punto).
+*   **UI Testing (Web):** Introduce UI testing using frameworks like Selenium or Playwright to automate testing of web application workflows.
+
+## Documentation
+
+*   **API Documentation:** If any RESTful APIs are exposed (even internally), document them using standards like OpenAPI.
+*   **Developer Documentation:** Expand on code comments, add module-level documentation explaining architecture and data flow for easier onboarding of new developers.
+*   **User Manuals:** Create user guides for both CLI and Web versions, explaining features and usage for end-users (especially admins).
+
+## Refactoring & Technical Debt
+
+*   **Data Persistence Strategy:** Review the hybrid JSON/SQLAlchemy approach. Identify if more modules should migrate to SQLAlchemy for better data integrity, querying, and scalability, or if the current JSON approach is adequate for the project's scale and privacy goals.
+*   **Code Deduplication:** Identify and refactor common patterns or duplicated code (e.g., similar filtering logic in different modules) into shared utilities.
+*   **Modularity:** Further improve modularity between blueprints to reduce tight coupling.
+*   **Configuration Management (`config.py`):** Review the structure of `config.py`. Consider using environment variables for sensitive information (API keys, secret key) rather than hardcoding, especially for any potential deployment.
+*   **Front-end Assets:** For the web version, consider using tools for managing and bundling CSS/JS assets if complexity grows.

--- a/about this app.txt
+++ b/about this app.txt
@@ -6,21 +6,44 @@ Famigliappってアプリを作りたい
 
 一般販売の予定は無い。
 
-【現在の開発状況】
-主要な掲示板、ポイント管理、カレンダー、タスク機能まで実装が進み、通知やAI解析を含む各種自動化も動作しています。
-Web版とCLI版双方が利用可能で、テストも整備されています。
-継続的に機能追加と改善を行っています。
+## Current Development Status and Implementation Overview
 
+The Famigliapp project has reached a mature prototype stage. A significant number of core functionalities, as originally envisioned in the detailed specifications below, have been implemented and are accessible through both a Command-Line Interface (CLI) and a Flask-based web application.
 
+Key implemented areas include:
+*   **User and Points Management:** The Punto system for tracking and managing user points (AhvPunto, OzePunto, UnitoPunto) is functional, including history, rankings, and admin editing capabilities.
+*   **Content Modules/Bulletin Boards:** Various themed boards such as Posts (general), Bravissimo (audio praise), Intrattenimento (entertainment), Corso (seminar feedback), Seminario (lesson feedback), Principessina (baby reports), and Monsignore (image columns) are operational, generally supporting posting, viewing, and filtering.
+*   **Interactive Features:** Quest Box for task management, Scatola di Capriccio for private feedback and admin surveys, Vote Box for polls, and Nedari Box for requests are available.
+*   **Calendario:** A shared calendar with event management and an advanced shift management system for admins (including rule-based warnings and drag-and-drop assignment) is in place.
+*   **Reporting & Analysis:** Resoconto for work reports features daily AI analysis (via Claude API) viewable by admins, CSV export, and user contribution rankings.
+*   **Notifications:** Email, LINE Notify, and Pushbullet notifications are integrated for various application events.
+*   **Data Storage:** The application primarily uses JSON files for feature-specific data, with SQLAlchemy and a SQLite database managing core user information, generic posts, and points history.
 
+For a comprehensive list of currently implemented features and their details, please refer to the main `README.md` file. The `TODO.md` file outlines planned enhancements, features from the original specification that are still pending or partially implemented, and areas for future work. The general approach has been to build out the features with a focus on functionality, with ongoing efforts to refine the user interface, particularly for the web version.
 
+## Key Development Milestones/History (Recent)
 
+*   Integration of a Flask web interface alongside the original CLI.
+*   Implementation of `flask run` compatibility for easier development server startup.
+*   Standardization of module naming conventions (e.g., 'Seminario' capitalization).
+*   Iterative refinements to CSS for calendar views, shift management UI, and event item display to improve clarity and usability.
+*   Ongoing updates to documentation (`README.md`, `TODO.md`) to reflect current project state.
 
+## Future Outlook
 
+The future development of Famigliapp will focus on several key areas, guided by the `TODO.md` document:
 
+*   **Full Specification Alignment:** Completing any remaining aspects of the original "【FamigliApp仕様】" detailed below, particularly around nuanced behaviors in Scatola di Capriccio, Quest Box lifecycle, and reminder systems.
+*   **Enhancements:** Improving existing features with more robust file handling (security, previews), user-configurable notifications, deeper Punto integrations, and a more unified and mobile-responsive web UI.
+*   **Stability and Performance:** Addressing potential bugs, strengthening error handling, and optimizing performance, especially concerning the use of JSON files for data storage.
+*   **Testing and Documentation:** Significantly increasing test coverage (unit, integration, UI) and expanding developer and user documentation.
+*   **Refactoring:** Evaluating the long-term data persistence strategy (JSON vs. database), improving code modularity, and enhancing configuration management for security and scalability.
 
+The long-term vision remains to provide a rich, private, and engaging digital environment for the target user group.
 
-
+---
+(Original Detailed Specifications Below)
+---
 
 【FamigliApp仕様】
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,7 +51,7 @@ def create_app() -> "Flask":
     from .invites import bp as invites_bp
     from .calendario import bp as calendario_bp
     from .resoconto import bp as resoconto_bp
-    from .seminario import bp as seminario_bp
+    from .Seminario import bp as seminario_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(punto_bp)

--- a/app/calendario/__init__.py
+++ b/app/calendario/__init__.py
@@ -1,6 +1,7 @@
 """Calendario blueprint."""
 
 from flask import Blueprint
+from . import utils # Assuming utils.py is in the same directory
 
 
 bp = Blueprint(
@@ -9,6 +10,11 @@ bp = Blueprint(
     url_prefix="/calendario",
     template_folder="templates/calendario",
 )
+
+# Register the filter
+@bp.app_template_filter('initials')
+def initials_template_filter(name):
+    return utils.another_initials_filter_for_japanese_names(name)
 
 from . import routes  # noqa: E402,F401
 

--- a/app/calendario/forms.py
+++ b/app/calendario/forms.py
@@ -29,6 +29,8 @@ class EventForm(FlaskForm):
             ("hug", "ハグの日"),
             ('kouza', '講座'),
             ('shucchou', '出張'),
+            ('mommy', 'マミー系'),
+            ('tattoo', 'タトゥー'),
             ("other", "その他"),
         ],
         validators=[DataRequired()],

--- a/app/calendario/templates/calendario/event_form.html
+++ b/app/calendario/templates/calendario/event_form.html
@@ -53,7 +53,7 @@ function toggleTimeField(categoryValue) {
     // 親の p タグを取得して表示/非表示を切り替える
     const timeFieldWrapper = timeField.closest('p');
 
-    if (categoryValue === 'kouza' || categoryValue === 'lesson' || categoryValue === 'other') {
+    if (categoryValue === 'kouza' || categoryValue === 'lesson' || categoryValue === 'other' || categoryValue === 'mommy' || categoryValue === 'tattoo') {
         if (timeFieldWrapper) timeFieldWrapper.style.display = '';
         // Fallback if p tag is not found (should not happen with current structure)
         else {

--- a/app/calendario/templates/calendario/month_view.html
+++ b/app/calendario/templates/calendario/month_view.html
@@ -23,16 +23,17 @@
         </div>
     </div>
 
-    <table class="calendar table table-bordered">
-        <thead class="table-light">
-            <tr>
-                <th style="width: 14.28%;">月</th>
-                <th style="width: 14.28%;">火</th>
-                <th style="width: 14.28%;">水</th>
-                <th style="width: 14.28%;">木</th>
-                <th style="width: 14.28%;">金</th>
-                <th style="width: 14.28%;">土</th>
-                <th style="width: 14.28%;">日</th>
+    <div class="calendar-scroll-container">
+        <table class="calendar table table-bordered">
+            <thead class="table-light">
+                <tr>
+                <th>月</th>
+                <th>火</th>
+                <th>水</th>
+                <th>木</th>
+                <th>金</th>
+                <th>土</th>
+                <th>日</th>
             </tr>
         </thead>
         <tbody>
@@ -40,12 +41,12 @@
             <tr>
                 {% for d in week %}
                 <td class="{% if d.month != month.month %}other-month text-muted bg-light{% else %}calendar-day{% endif %}"
-                    {% if d.month == month.month %}data-date="{{ d.isoformat() }}"{% endif %}
-                    style="vertical-align: top; height: 120px; overflow-y: auto; padding: 2px;"> {# Reduced padding for more space #}
-                    <div class="day-number fw-bold" style="font-size: 0.9em; margin-bottom: 2px;">{{ d.day }}</div>
+                    {% if d.month == month.month %}data-date="{{ d.isoformat() }}"{% endif %}>
+                    <div class="cell-content-wrapper">
+                        <div class="day-number fw-bold">{{ d.day }}</div>
 
-                    {# Removed the all-encompassing event-grid-container #}
-                    {% set events_for_day = events_by_date.get(d.isoformat(), []) %}
+                        {# Removed the all-encompassing event-grid-container #}
+                        {% set events_for_day = events_by_date.get(d.isoformat(), []) %}
                     {% for ev in events_for_day %}
                         {# Logic to open shift-grid-container #}
                         {% if ev.category == 'shift' and (loop.first or loop.previtem.category != 'shift') %}
@@ -53,9 +54,9 @@
                         {% endif %}
 
                         {% if ev.category == 'shift' %}
-                            <div class="shift-grid-item event-shift-item calendar-event-text-compact d-flex align-items-center justify-content-between" draggable="true" data-event-id="{{ ev.id }}">
-                                <span class="flex-grow-1" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-                                    {{ ev.cleaned_title or ev.employee }}
+                            <div class="shift-grid-item event-grid-item event-shift event-shift-item calendar-event-text-compact d-flex align-items-center justify-content-between" draggable="true" data-event-id="{{ ev.id }}">
+                                <span class="flex-grow-1 initial-text-{{ (ev.employee or ev.cleaned_title)|lower|replace(' ', '_') }}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                                    {{ (ev.cleaned_title or ev.employee) | initials }}
                                 </span>
                                 <div class="event-actions" style="white-space: nowrap;">
                                     {# Shift events: Copy, Move #}
@@ -88,12 +89,14 @@
                         </div> {# Close shift-grid-container #}
                         {% endif %}
                     {% endfor %}
+                    </div> {# Close cell-content-wrapper #}
                 </td>
                 {% endfor %}
             </tr>
         {% endfor %}
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    </div>
     <div class="mt-3">
         <a href="{{ url_for('calendario.add') }}" class="btn btn-success">新しい予定を追加</a>
         {% if user.role == 'admin' %}

--- a/app/calendario/templates/calendario/shift_manager.html
+++ b/app/calendario/templates/calendario/shift_manager.html
@@ -47,66 +47,88 @@
 </div>
 <div class="shift-users my-3">
     <strong>従業員リスト (ドラッグ＆ドロップまたはクリックでセルに追加):</strong><br>
-    {% for emp in employees %}<div class="employee-box" draggable="true" data-emp="{{ emp }}">{{ emp }}</div>{% endfor %}
+    {% for emp in employees %}<div class="employee-box initial-text-{{ emp|lower|replace(' ', '_') }}" draggable="true" data-emp="{{ emp }}">{{ emp | initials }}</div>{% endfor %}
 </div>
 
 <div class="employee-stats-summary card mb-3">
     <div class="card-header">今月の集計</div>
     <div class="card-body" data-current-month="{{ month.strftime('%Y-%m') }}">
         {% if employees %}
-            {% for emp in employees %}
-                <p style="margin: 5px 0;">
-                    {{ emp }}:
-                    勤務日数 <span class="work-count" data-emp="{{ emp }}">{{ counts.get(emp, 0) }}</span>日,
-                    休日数 <span class="off-count" data-emp="{{ emp }}">{{ off_counts.get(emp, 0) }}</span>日
-                </p>
-            {% endfor %}
+                <div class="employee-summary-grid"> {# New grid container #}
+                    {% for emp in employees %}
+                        <div class="employee-summary-item user-summary-{{ emp|lower }}"> {# New grid item for each employee #}
+                            <p style="margin: 5px 0;">
+                                {{ emp }}:<br> {# Added <br> for better readability if text wraps #}
+                                勤務日数 <span class="work-count" data-emp="{{ emp }}">{{ counts.get(emp, 0) }}</span>日,<br>
+                                休日数 <span class="off-count" data-emp="{{ emp }}">{{ off_counts.get(emp, 0) }}</span>日
+                            </p>
+                        </div>
+                    {% endfor %}
+                </div>
         {% else %}<p>表示する従業員がいません。</p>{% endif %}
     </div>
 </div>
 
+{% if special_schedule_violations %}
+<div class="alert alert-warning mt-3" role="alert">
+    <h4><i class="bi bi-exclamation-triangle-fill"></i> 専門予定に関する警告</h4>
+    <ul class="mb-0">
+        {% for violation_msg in special_schedule_violations %}
+        <li>{{ violation_msg }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
 <form method="post">
     {{ form.hidden_tag() }}
     <input type="hidden" name="action" value="complete" id="action-field">
-    <table class="calendar table table-bordered">
-        <thead class="table-light"><tr><th>月</th><th>火</th><th>水</th><th>木</th><th>金</th><th>土</th><th>日</th></tr></thead>
-        <tbody>
+    <div class="calendar-scroll-container">
+        <table class="calendar table table-bordered">
+            <thead class="table-light"><tr><th>月</th><th>火</th><th>水</th><th>木</th><th>金</th><th>土</th><th>日</th></tr></thead>
+            <tbody>
         {% for week in weeks %}
             <tr>
             {% for d in week %}
                 <td class="{% if d.month != month.month %}other-month text-muted{% else %}shift-cell{% endif %}"
                     data-date="{{ d.isoformat() }}"
-                    style="{% if d.month != month.month %}background-color: #f8f9fa;{% endif %}">
-                    <div class="day-number">{{ d.day }}</div>
-                    <div class="violation-icons"></div>
-                    {# This div will now contain all events, including shifts and other event types #}
-                    <div class="assignments">
-                        {# Iterate through all events for the day from the new variable #}
-                        {% for ev in all_events_by_date.get(d.isoformat(), []) %}
-                            {% if ev.category == 'shift' %}
-                                {# Shifts are draggable and clickable for management #}
-                                <span class="assigned event-shift-item" draggable="true" data-emp="{{ ev.employee }}">{{ ev.employee }}</span>
-                            {% else %}
-                                {# Other events are for display only, not draggable in shift manager #}
-                                <div class="event-grid-item event-{{ ev.category }}" title="{{ ev.cleaned_title }}{% if ev.employee %} ({{ev.employee}}){% endif %}">
-                                    {% if ev.display_time %}<span class="event-time">{{ ev.display_time }}</span>{% endif %}
-                                    {{ ev.cleaned_title }}
-                                    {% if ev.employee and ev.category != 'shift' %}
-                                        <small class="event-employee"> ({{ ev.employee }})</small>
-                                    {% endif %}
-                                </div>
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-                    {# The hidden input still needs to be populated ONLY with shift employees #}
-                    {# The 'assignments' variable passed to the template now specifically holds shift employees for form submission #}
-                    <input type="hidden" name="d-{{ d.isoformat() }}" value="{{ ','.join(assignments.get(d.isoformat(), [])) }}">
+                    {% if d.month != month.month %}style="background-color: #f8f9fa;"{% endif %}> {# Keep conditional background style #}
+                    <div class="cell-content-wrapper">
+                        <div class="day-number">{{ d.day }}</div>
+                        <div class="violation-icons"></div>
+                        <input type="hidden" name="d-{{ d.isoformat() }}" value="{{ ','.join(assignments.get(d.isoformat(), [])) }}">
+
+                        <div class="manager-other-events-container">
+                            {% for ev in all_events_by_date.get(d.isoformat(), []) %}
+                                {% if ev.category != 'shift' %}
+                                    {# Other events are for display only, not draggable in shift manager #}
+                                    <div class="event-grid-item event-{{ ev.category }}" title="{{ ev.cleaned_title }}{% if ev.employee %} ({{ev.employee}}){% endif %}">
+                                        {% if ev.display_time %}<span class="event-time">{{ ev.display_time }}</span>{% endif %}
+                                        {{ ev.cleaned_title }}
+                                        {% if ev.employee %} {# removed ev.category != 'shift' as this block is already for non-shifts #}
+                                            <small class="event-employee"> ({{ ev.employee }})</small>
+                                        {% endif %}
+                                    </div>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+
+                        <div class="assignments shift-manager-assignment-grid">
+                            {% for ev in all_events_by_date.get(d.isoformat(), []) %}
+                                {% if ev.category == 'shift' %}
+                                    {# Shifts are draggable and clickable for management #}
+                                    <span class="assigned event-grid-item event-shift event-shift-item initial-text-{{ ev.employee|lower|replace(' ', '_') }}" draggable="true" data-emp="{{ ev.employee }}">{{ ev.employee | initials }}</span>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                    </div> {# Close cell-content-wrapper #}
                 </td>
             {% endfor %}
             </tr>
         {% endfor %}
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    </div>
     <div class="mt-3">
         <button type="submit" class="btn btn-success" onclick="document.getElementById('action-field').value='complete'">保存</button>
         <button type="submit" class="btn btn-info" onclick="document.getElementById('action-field').value='notify'">保存して通知</button>

--- a/app/calendario/templates/calendario/shift_rules.html
+++ b/app/calendario/templates/calendario/shift_rules.html
@@ -9,6 +9,7 @@
         <input type="hidden" name="employee_attributes" id="employee_attributes_hidden" value="{{ form.employee_attributes.data or '' }}">
         <input type="hidden" name="required_attributes" id="required_attributes_hidden" value="{{ form.required_attributes.data or '' }}">
         <input type="hidden" name="defined_attributes_json_str" id="defined_attributes_json_str">
+        <input type="hidden" name="specialized_requirements_json_str" id="specialized_requirements_json_str">
 
         <div class="card mb-3">
             <div class="card-header">基本設定</div>
@@ -120,6 +121,40 @@
             </div>
         </div>
 
+        <!-- Specialized Schedule Settings Card -->
+        <div class="card mb-3">
+            <div class="card-header">専門予定設定</div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-4 mb-3">
+                        <label for="special_event_category" class="form-label">予定ジャンル</label>
+                        <select id="special_event_category" class="form-select form-select-sm">
+                            {% for cat_val, cat_name in special_rule_categories %}
+                                <option value="{{ cat_val }}">{{ cat_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <label for="special_required_staff" class="form-label">必須担当者 (複数選択可)</label>
+                        <select id="special_required_staff" class="form-select form-select-sm" multiple size="3">
+                            {% for emp in employees %}
+                                <option value="{{ emp }}">{{ emp }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-2 mb-3 align-self-end">
+                        <button type="button" id="add_special_requirement_button" class="btn btn-outline-primary btn-sm w-100">追加</button>
+                    </div>
+                </div>
+                <hr>
+                <h5>現在の専門予定ルール</h5>
+                <ul id="specialized_rules_list_display" class="list-group">
+                    <!-- JS will populate this -->
+                </ul>
+            </div>
+        </div>
+        <!-- End of Specialized Schedule Settings Card -->
+
         <hr class="my-4">
         <h2>現在設定されているルール詳細</h2>
 
@@ -175,6 +210,7 @@
 </div>
 <script>
     window.initialShiftAttributes = {{ attributes|tojson|safe }};
+    window.initialSpecializedRequirements = {{ specialized_requirements|tojson|safe }};
 </script>
 <script src="{{ url_for('static', filename='js/shift_rules.js') }}" defer></script>
 {% endblock %}

--- a/app/calendario/templates/calendario/week_view.html
+++ b/app/calendario/templates/calendario/week_view.html
@@ -49,7 +49,7 @@
                         {% endif %}
 
                         {% if event.category == 'shift' %}
-                            <div class="shift-grid-item event-shift-item calendar-event-text-compact d-flex align-items-center justify-content-between" draggable="true" data-event-id="{{ event.id }}">
+                            <div class="shift-grid-item event-grid-item event-shift event-shift-item calendar-event-text-compact d-flex align-items-center justify-content-between" draggable="true" data-event-id="{{ event.id }}">
                                 <span class="flex-grow-1" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
                                     {{ event.cleaned_title or event.employee }}
                                 </span>
@@ -104,7 +104,7 @@
                         {% endif %}
 
                         {% if event.category == 'shift' %}
-                            <div class="shift-grid-item event-shift-item calendar-event-text-compact d-flex align-items-center justify-content-between" draggable="true" data-event-id="{{ event.id }}">
+                            <div class="shift-grid-item event-grid-item event-shift event-shift-item calendar-event-text-compact d-flex align-items-center justify-content-between" draggable="true" data-event-id="{{ event.id }}">
                                 <span class="flex-grow-1" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
                                     {{ event.cleaned_title or event.employee }}
                                 </span>

--- a/app/static/js/shift_rules.js
+++ b/app/static/js/shift_rules.js
@@ -1,0 +1,81 @@
+document.addEventListener('DOMContentLoaded', function() {
+    // Check if we are on the shift_rules page by looking for a specific element
+    const specializedRulesListDisplay = document.getElementById('specialized_rules_list_display');
+    if (!specializedRulesListDisplay) {
+        // Not on the correct page, or the element is missing. Do nothing.
+        return;
+    }
+
+    // Initialize specializedRequirements from data passed by the template
+    // The template should render: <script> let initialSpecializedRequirements = {{ specialized_requirements|tojson|safe }}; </script>
+    // This script should be placed *before* this external JS file, or the data passed some other way.
+    // For now, assuming `initialSpecializedRequirements` is globally available or will be made so.
+    // Let's try to get it from a global variable if it's set by an inline script in the HTML.
+    let specializedRequirements = typeof initialSpecializedRequirements !== 'undefined' ? initialSpecializedRequirements : {};
+
+    const categorySelect = document.getElementById('special_event_category');
+    const staffSelect = document.getElementById('special_required_staff');
+    const addButton = document.getElementById('add_special_requirement_button');
+    const hiddenInput = document.getElementById('specialized_requirements_json_str');
+
+    function renderSpecializedRules() {
+        specializedRulesListDisplay.innerHTML = ''; // Clear current display
+
+        if (Object.keys(specializedRequirements).length === 0) {
+            const listItem = document.createElement('li');
+            listItem.className = 'list-group-item text-muted';
+            listItem.textContent = '現在、専門予定ルールはありません。';
+            specializedRulesListDisplay.appendChild(listItem);
+        } else {
+            for (const category in specializedRequirements) {
+                const staffList = specializedRequirements[category].join(', ');
+                const listItem = document.createElement('li');
+                listItem.className = 'list-group-item d-flex justify-content-between align-items-center';
+                listItem.innerHTML = `<span><strong>${category}:</strong> ${staffList}</span>
+                                      <button type="button" class="btn btn-danger btn-sm delete-special-rule" data-category="${category}">削除</button>`;
+                specializedRulesListDisplay.appendChild(listItem);
+            }
+        }
+        // Update the hidden input field
+        if (hiddenInput) {
+            hiddenInput.value = JSON.stringify(specializedRequirements);
+        }
+    }
+
+    if (addButton) {
+        addButton.addEventListener('click', function() {
+            const selectedCategory = categorySelect.value;
+            const selectedStaff = Array.from(staffSelect.selectedOptions).map(option => option.value);
+
+            if (!selectedCategory) {
+                alert('予定ジャンルを選択してください。');
+                return;
+            }
+            if (selectedStaff.length === 0) {
+                alert('必須担当者を少なくとも1人選択してください。');
+                return;
+            }
+
+            specializedRequirements[selectedCategory] = selectedStaff;
+            renderSpecializedRules();
+        });
+    }
+
+    // Event delegation for delete buttons
+    specializedRulesListDisplay.addEventListener('click', function(event) {
+        if (event.target.classList.contains('delete-special-rule')) {
+            const categoryToDelete = event.target.dataset.category;
+            if (categoryToDelete && specializedRequirements.hasOwnProperty(categoryToDelete)) {
+                delete specializedRequirements[categoryToDelete];
+                renderSpecializedRules();
+            }
+        }
+    });
+
+    // Initial render on page load
+    renderSpecializedRules();
+
+    // It's good practice to also ensure the hidden field for other rules are populated if this script were to manage them.
+    // For now, this script ONLY manages specialized_requirements.
+    // The existing hidden fields (forbidden_pairs_hidden etc.) are assumed to be handled by other means or are static.
+});

--- a/run.py
+++ b/run.py
@@ -12,18 +12,21 @@ from app.resoconto import utils as resoconto_utils
 from app.resoconto import tasks as resoconto_tasks
 from app.resoconto.tasks import start_scheduler
 from app.intrattenimento.tasks import start_scheduler as start_intrattenimento_scheduler
-from app.seminario.tasks import start_scheduler as start_seminario_scheduler
+from app.Seminario.tasks import start_scheduler as start_seminario_scheduler
 from app.principessina.tasks import start_scheduler as start_principessina_scheduler
 from app.corso.tasks import start_scheduler as start_corso_scheduler
 from app.principessina import utils as principessina_utils
 from app.quest_box import utils as quest_utils
-from app.seminario import utils as seminario_utils
+from app.Seminario import utils as seminario_utils
 from app.bravissimo import utils as bravissimo_utils
 from app.scatola_capriccio import utils as scatola_capriccio_utils
 from app.monsignore import utils as monsignore_utils
 from app.calendario import utils as calendario_utils
 from app.invites import utils as invite_utils
 
+from app import create_app
+
+app = create_app()
 
 def display_menu(user: Dict[str, str]):
     while True:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -23,7 +23,7 @@ body {
 }
 
 .container {
-    max-width: 960px;
+    max-width: 1140px;
     margin: 20px auto;
     padding: 20px;
     background: #fff;
@@ -76,17 +76,39 @@ table { /* General table styling */
 }
 
 /* Calendar specific table layouts */
-.calendar, .calendar-grid {
-    table-layout: auto;
-    width: 100%; /* Ensure it's still 100% */
+.calendar, .calendar-grid { /* .calendar-grid might be for other views, ensure fixed layout is desired there too, or make selector more specific e.g. table.calendar */
+    table-layout: fixed; /* Ensured */
+    width: 980px !important; /* Set fixed width */
+    margin: 0 auto; /* Ensured for centering */
+    /* max-width: fit-content; and width: auto; removed */
 }
 
-/* Remove word-break from calendar cells if item content itself handles truncation */
+/* Styles for calendar th and td cells */
+.calendar th,
 .calendar td.calendar-day,
-.calendar-grid td.calendar-cell {
-    /* If there were word-break: break-all; or overflow-wrap: break-word; here, consider removing */
-    /* For now, no specific removal, assuming they don't exist or aren't problematic */
+.calendar td.shift-cell {
+    width: 140px !important;       /* Strict width for all calendar cells */
+    min-width: 140px !important;   /* Strict width */
+    max-width: 140px !important;   /* Strict width */
+    vertical-align: top;         /* Ensured for td, good default for th */
+    border: 1px solid #ddd;      /* Ensured */
 }
+
+/* Specific overrides for td cells if needed, grouped for common properties */
+.calendar td.calendar-day,
+.calendar td.shift-cell {
+    height: 150px;       /* Fixed height for cells (Preserved) */
+    padding: 0;          /* Padding reset for td cells */
+    /* Previous min-width/max-width specific to td removed in favor of the common rule above */
+}
+
+/* Specific overrides for th cells if needed (padding comes from general th rule or can be set here) */
+.calendar th {
+    /* background: #f9f9f9; /* from general th rule */
+    /* padding: 8px; /* from general th rule, or set specific if 0 is not desired from common rule if it was applied there */
+    /* width calc removed, now uses 140px !important from common rule */
+}
+
 
 table { /* This is a duplicate, ensure it's merged or organized if needed */
     width: 100%;
@@ -165,7 +187,9 @@ ul {
     background: #e3f2fd;
     padding: 4px 8px;
     margin: 2px;
-    display: inline-block;
+    display: inline-flex; /* Changed from inline-block */
+    align-items: center; /* Added */
+    white-space: nowrap; /* Added */
     border-radius: 4px;
     cursor: move;
 }
@@ -178,9 +202,52 @@ ul {
     display: block;
     background: #bbdefb;
     margin: 2px 0;
-    padding: 2px 4px;
+    padding: 2px 1px !important; /* Padding reverted for shift items */
     border-radius: 4px;
     cursor: pointer;
+    border: 1px solid #777;
+    overflow: hidden !important; /* Ensured */
+    white-space: nowrap !important; /* Ensured */
+    text-overflow: ellipsis !important; /* Ensured */
+    height: auto !important; /* Maintained */
+    line-height: 1.2 !important; /* Adjusted line-height */
+    width: 125px !important; /* Verified fixed width */
+    min-width: 125px !important; /* Verified fixed min-width */
+    max-width: 125px !important; /* Verified fixed max-width */
+    box-sizing: border-box; /* Maintained */
+    flex-shrink: 0; /* Maintained */
+    word-break: normal !important; /* Restored from break-word */
+}
+
+.shift-manager-assignment-grid {
+    display: grid !important; /* Restored grid display */
+    grid-template-columns: repeat(4, 125px) !important; /* Restored grid columns */
+    gap: 3px !important; /* Restored gap */
+    justify-content: start !important; /* Restored justify-content */
+    padding-top: 2px; /* Maintained */
+    margin-top: 5px; /* Maintained */
+}
+
+/* .shift-manager-assignment-grid .event-grid-item rule is removed as non-shift events are now in their own container. */
+
+/* New container for non-shift events in manager view */
+.manager-other-events-container {
+    display: grid; /* Added */
+    grid-template-columns: 1fr; /* Added for single column layout */
+    justify-items: start; /* Added to align items to the left */
+    gap: 3px; /* Added for spacing between items, consistent with other grids */
+    margin-bottom: 5px; /* Space between non-shift events and shift grid (verified) */
+}
+
+/* Adjust display of shift items within shift manager */
+.shift-manager-assignment-grid > .assigned {
+    /* Base styling (width, overflow, etc.) is inherited from .shift-cell .assigned !important rules */
+    /* padding is handled by the more specific rule below or inherited from .shift-cell .assigned */
+    /* line-height: 1.3; /* This is overridden by .shift-cell .assigned's 1.2 !important or the specific rule below */
+    height: auto; /* Verified specific height */
+    min-height: unset; /* Crucial override for this context */
+    margin: 2px 0; /* Verified margin (consistent with .shift-cell .assigned) */
+    /* text-overflow, white-space, etc. are inherited from .shift-cell .assigned */
 }
 
 /* For compact calendar event text */
@@ -194,9 +261,10 @@ ul {
 /* For the container of events within a calendar cell (month view) */
 .event-grid-container {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-    gap: 3px;
-    padding-top: 2px;
+    grid-template-columns: 1fr; /* Changed to a single column layout */
+    gap: 3px; /* Verified */
+    padding-top: 2px; /* Verified */
+    justify-items: start; /* Align items to the start of the column */
 }
 
 .event-grid-container-week {
@@ -207,14 +275,72 @@ ul {
 }
 
 .event-grid-item {
-    padding: 2px 4px;
-    border: 1px solid #e0e0e0;
-    border-radius: 3px;
-    background-color: #f9f9f9; /* Default background */
-    word-break: break-word;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    /* Common appearance properties */
+    line-height: 1.2 !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    box-sizing: border-box !important;
+
+    /* Defaults to be overridden, or ensure they are not overly specific */
+    border: 1px solid #e0e0e0; /* Kept as a base */
+    border-radius: 3px; /* Kept as a base */
+    background-color: #f9f9f9; /* Kept as a base */
+    height: auto !important; /* Maintained */
+    flex-shrink: 0; /* Maintained, if items can be flex children */
+    /* Removed specific width, min-width, max-width, font-size, padding */
+    /* word-break: normal !important; /* Covered by white-space: nowrap */
 }
+
+/* Styles for non-shift events (default for .event-grid-item) */
+.event-grid-item:not(.event-shift) {
+    width: 165px !important;
+    min-width: 165px !important;
+    max-width: 165px !important;
+    font-size: 0.85em !important;
+    padding: 2px 4px !important;
+    /* Inherits line-height, text handling etc. from base .event-grid-item */
+}
+
+/* Styles for non-shift events specifically in the Shift Manager */
+.manager-other-events-container .event-grid-item:not(.event-shift) {
+    width: 160px !important;
+    min-width: 160px !important;
+    max-width: 160px !important;
+    font-size: 0.85em !important; /* Explicitly re-stated for clarity */
+    padding: 2px 4px !important; /* Explicitly re-stated for clarity */
+    /* Inherits line-height, text handling etc. from base .event-grid-item */
+}
+
+/* Common styles for ALL shift event items (main calendar and manager) */
+.event-grid-item.event-shift {
+    flex: 0 0 125px !important; /* For flex contexts if its container is flex */
+    width: 125px !important;
+    min-width: 125px !important;
+    max-width: 125px !important;
+    font-size: 0.85em !important; /* Default font size for shifts */
+    padding: 2px 4px !important;   /* Default padding for shifts (e.g., main calendar) */
+    background-color: gray !important; /* Shift-specific appearance */
+    /* color: white !important; /* Removed as per subtask - color should be from initial-text-* or event-shift-item */
+    /* Inherits line-height, text handling etc. from base .event-grid-item */
+    /* Note: .shift-grid-item also gets these properties by having .event-grid-item.event-shift classes */
+    /* Note: .assigned items in manager also get these by having .event-grid-item.event-shift classes */
+}
+
+/* Specific styles for shift events in the Shift Manager, overriding common shift styles */
+.shift-manager-assignment-grid span.assigned.event-grid-item.event-shift {
+    padding: 2px 1px !important; /* Overrides padding for consecutive day text */
+    font-size: 0.9em !important;  /* Specific font size for manager shifts */
+    /* Inherits flex, width, min-width, max-width, background-color, color, line-height, etc., */
+    /* from .event-grid-item and the common .event-grid-item.event-shift rule above */
+    width: 125px !important; /* Re-stated for clarity/override */
+    min-width: 125px !important; /* Re-stated for clarity/override */
+    max-width: 125px !important; /* Re-stated for clarity/override */
+    flex: 0 0 125px !important; /* Re-stated for clarity/override */
+    /* background-color, color are inherited from .event-grid-item.event-shift */
+}
+
+/* The old .manager-other-events-container .event-grid-item rule (without :not) is now removed. */
 
 .btn-xs-custom {
     padding: 0.1rem 0.3rem;
@@ -226,37 +352,50 @@ ul {
 
 /* Shift-specific 4-column grid container */
 .shift-grid-container {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr); /* 4 equal columns */
-    gap: 3px; /* Gap between shift items */
-    padding-top: 2px;
+    display: grid !important; /* Restored grid display */
+    grid-template-columns: repeat(4, 125px) !important; /* Restored grid columns */
+    gap: 3px !important; /* Restored gap */
+    justify-content: start !important; /* Restored justify-content */
+    padding-top: 2px; /* Maintained */
 }
 
 /* Individual shift items within the shift grid */
 .shift-grid-item {
-    padding: 2px 4px;
+    padding: 2px 1px !important; /* Padding reverted for shift items */
     border: 1px solid #777; /* Slightly darker border for shift items */
     border-radius: 3px;
     /* background-color and color will be set by .event-shift-item */
-    word-break: break-word;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    /* white-space: nowrap; /* Might be too restrictive if shift details are longer */
+    white-space: nowrap !important; /* Ensured */
+    word-break: normal !important; /* Ensured */
+    overflow: hidden !important; /* Ensured */
+    text-overflow: ellipsis !important; /* Ensured */
+    width: 125px !important; /* Verified fixed width */
+    min-width: 125px !important; /* Verified fixed min-width */
+    max-width: 125px !important; /* Verified fixed max-width */
+    height: auto !important; /* Maintained */
+    line-height: 1.2 !important; /* Adjusted line-height */
+    box-sizing: border-box; /* Maintained */
+    flex-shrink: 0; /* Maintained */
 }
 
 /* Ensure action buttons in both shift and general events do not shrink and buttons themselves don't wrap */
 .event-grid-item .event-actions,
 .shift-grid-item .event-actions {
-    flex-shrink: 0;
-    white-space: nowrap; /* Ensures buttons stay in a single line */
+    display: flex; /* Added */
+    flex-wrap: nowrap; /* Added (consistent with white-space: nowrap) */
+    justify-content: space-between; /* Added to space out buttons */
+    gap: 2px; /* Added for spacing between buttons */
+    flex-shrink: 0; /* Maintained */
+    white-space: nowrap; /* Maintained: Ensures buttons stay in a single line if flex properties are not fully supported or overridden */
 }
 
 /* Ensure title/text part in both shift and general events truncates properly */
 .event-grid-item > .flex-grow-1, /* Targets the span that should truncate in general events */
 .shift-grid-item > .flex-grow-1 { /* Targets the span that should truncate in shift events */
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap; /* Ensures text is on a single line for ellipsis to work */
+    overflow: hidden; /* Keep hidden to manage overflow with multi-line */
+    /* text-overflow: ellipsis; */ /* Removed for multi-line */
+    white-space: normal; /* Changed from nowrap */
+    word-break: break-all; /* Added for better CJK wrapping */
     min-width: 0;     /* Crucial for text-overflow in flex items */
 }
 
@@ -299,6 +438,22 @@ ul {
     margin-right: 0.3em; /* Space between time and title */
 }
 
+.day-number {
+    font-size: 0.9em;
+    margin-bottom: 2px;
+    font-weight: bold; /* Consolidated from month_view's fw-bold class */
+}
+
+.cell-content-wrapper {
+    width: 100%; /* Maintained */
+    height: 100%; /* Preserved */
+    overflow-x: auto; /* Changed back from hidden */
+    overflow-y: auto; /* Preserved */
+    padding: 5px; /* Preserved */
+    box-sizing: border-box; /* Preserved */
+    /* max-width, min-width for cell-content-wrapper were removed in a previous step, this is correct. */
+}
+
 .btn-custom-edit {
     background-color: navy !important; /* 紺色 */
     color: white !important; /* 文字色 白 */
@@ -307,19 +462,21 @@ ul {
     font-size: 0.75em;
     line-height: 1.2;
     border-radius: 0.2rem;
+    text-decoration: none !important;
 }
 
 .btn-custom-edit:hover {
     background-color: darkblue !important;
     border-color: darkblue !important;
     color: white !important;
+    text-decoration: none !important;
 }
 
 .btn-custom-copy {
     background-color: orange !important; /* オレンジ */
     color: white !important; /* 文字色 白 */
     border: 1px solid orange !important; /* オレンジの枠 */
-    padding: 0.1rem 0.3rem;
+    padding: 0.1rem 0.25rem;
     font-size: 0.75em;
     line-height: 1.2;
     border-radius: 0.2rem;
@@ -346,3 +503,64 @@ ul {
     border-color: #A0522D !important;
     color: white !important;
 }
+
+.employee-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr); /* 4 equal columns */
+    gap: 10px; /* Adjust gap as needed */
+}
+
+.employee-summary-item {
+    padding: 10px; /* Added/Adjusted padding */
+    border-width: 4px;
+    border-style: solid;
+    /* Default border color if a specific user class isn't matched, or remove if not needed */
+    border-color: #ccc; /* Light grey default, can be overridden */
+    margin-bottom: 5px; /* Add some space between items if the gap isn't enough vertically */
+}
+
+/* User-specific borders */
+.user-summary-raito { border-color: #000000; } /* Light Grey for 'raito' as white might be invisible */
+.user-summary-hitomi { border-color: #0000FF; } /* Vivid Blue */
+.user-summary-sara { border-color: #FFA500; } /* Vivid Orange */
+.user-summary-jun { border-color: #800020; } /* Burgundy */
+.user-summary-nanchan { border-color: #90EE90; } /* Light Green */
+.user-summary-hachi { border-color: #40E0D0; } /* Light Turquoise */
+.user-summary-kie { border-color: #ffd700; } /* Dark Yellow (Amber) */
+.user-summary-gumi { border-color: #C71585; } /* Dark Pink (MediumVioletRed) */
+
+/* User-specific initial colors */
+.initial-text-raito { color: #000000 !important; } /* Black, was White */
+.initial-text-hitomi { color: #0000FF !important; } /* Vivid Blue */
+.initial-text-sara { color: #FFA500 !important; } /* Vivid Orange */
+.initial-text-jun { color: #800020 !important; } /* Burgundy */
+.initial-text-nanchan { color: #90EE90 !important; } /* Light Green */
+.initial-text-hachi { color: #40E0D0 !important; } /* Light Turquoise */
+.initial-text-kie { color: #ffd700 !important; } /* Gold (consistent with border change) */
+.initial-text-gumi { color: #C71585 !important; } /* Dark Pink (MediumVioletRed) */
+
+.calendar-scroll-container {
+    overflow-x: auto; /* Ensured */
+    max-width: 100%;  /* Added */
+    padding-bottom: 1rem; /* Added */
+    /* overflow-y and max-height from old rule removed as not specified */
+}
+
+/* New rule for shift events on main calendar with increased specificity */
+div.shift-grid-item.event-grid-item.event-shift {
+    width: 125px !important;
+    min-width: 125px !important;
+    max-width: 125px !important;
+    padding: 2px 4px !important;
+    font-size: 0.85em !important;
+    line-height: 1.2 !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    box-sizing: border-box !important;
+    flex: 0 0 125px !important; /* Added flex property */
+}
+
+/* The "FINAL override" rule for div.shift-grid-item.event-grid-item.event-shift (width:135px, display:block) is removed. */
+/* The previous div.shift-grid-item.event-grid-item.event-shift (width:125px, flex property) is also removed by the earlier SEARCH block not finding it. */
+/* New rules will be added in subsequent steps. */

--- a/static/js/shift_manager.js
+++ b/static/js/shift_manager.js
@@ -2,6 +2,13 @@ document.addEventListener('DOMContentLoaded', () => {
   let selectedEmployees = [];
   const employeeBoxes = Array.from(document.querySelectorAll('.employee-box'));
 
+  function getInitialFromName(name) {
+    if (!name || name.length === 0) {
+        return "";
+    }
+    return name.charAt(0).toUpperCase();
+  }
+
   employeeBoxes.forEach(box => {
     box.addEventListener('click', e => {
       const empName = box.dataset.emp;
@@ -103,9 +110,11 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!empsInCell.includes(empName)) {
           empsInCell.push(empName);
           const newSpan = document.createElement('span');
-          newSpan.className = 'assigned';
+          newSpan.className = 'assigned event-shift-item'; // Added event-shift-item for consistency
           newSpan.dataset.emp = empName;
-          newSpan.textContent = empName;
+          newSpan.textContent = getInitialFromName(empName); // Use helper to set initial
+          // Add user-specific color class for the initial text
+          newSpan.classList.add('initial-text-' + empName.toLowerCase().replace(/ /g, '_'));
           list.appendChild(newSpan);
           addSpanEventListeners(newSpan);
         }

--- a/tests/test_calendario_utils.py
+++ b/tests/test_calendario_utils.py
@@ -1,0 +1,134 @@
+import unittest
+from collections import defaultdict
+from app.calendario import utils as calendario_utils
+
+# Minimal mock for config.USERS if needed by the functions being tested
+# For get_specialized_schedule_violations, users_config is passed in, so direct mocking might not be needed
+# unless other utils called by it depend on a global config.USERS.
+# For now, we'll assume it's self-contained or users_config is sufficient.
+
+class TestCalendarioUtilsSpecializedViolations(unittest.TestCase):
+
+    def test_get_specialized_schedule_violations(self):
+        sample_events_base = [
+            # Shifts
+            {"date": "2023-01-01", "category": "shift", "employee": "sara"},
+            {"date": "2023-01-01", "category": "shift", "employee": "maya"},
+            {"date": "2023-01-02", "category": "shift", "employee": "jun"},
+            {"date": "2023-01-03", "category": "shift", "employee": "ken"},
+            {"date": "2023-01-04", "category": "shift", "employee": "sara"},
+            # Specialized Events
+            {"id": 1, "date": "2023-01-01", "title": "マミーイベント1", "category": "マミー系"},
+            {"id": 2, "date": "2023-01-02", "title": "タトゥーイベント1", "category": "タトゥー"},
+            {"id": 3, "date": "2023-01-03", "title": "マミーイベント2", "category": "マミー系"},
+            {"id": 4, "date": "2023-01-04", "title": "通常イベント", "category": "other"}, # No rule
+            {"id": 5, "date": "2023-01-05", "title": "マミーイベント3無人", "category": "マミー系"}, # No one on shift
+        ]
+
+        sample_rules_base = {
+            "specialized_requirements": {
+                "マミー系": ["sara", "hitomi"],
+                "タトゥー": ["jun"]
+            }
+            # "specialized_requirements_translation_map": { # Assuming direct keys for now
+            #     "マミー系": "マミー系",
+            #     "タトゥー": "タトゥー"
+            # }
+        }
+
+        mock_users_config = { # Simplified, only if needed by the function signature (it is)
+            "sara": {"name": "Sara"}, "hitomi": {"name": "Hitomi"},
+            "jun": {"name": "Jun"}, "ken": {"name": "Ken"}, "maya": {"name": "Maya"}
+        }
+
+        # Test Case 1: No violation for マミー系 (sara is on shift)
+        events_case1 = [e for e in sample_events_base if e['date'] == "2023-01-01" or e['id'] == 1]
+        violations = calendario_utils.get_specialized_schedule_violations(events_case1, sample_rules_base, mock_users_config)
+        self.assertEqual(len(violations), 0, "Test Case 1 Failed: Should be no violation for マミー系 with sara on shift.")
+
+        # Test Case 2: Violation for マミー系 (neither sara nor hitomi on shift, only ken)
+        events_case2 = [
+            {"date": "2023-01-03", "category": "shift", "employee": "ken"}, # Ken is on shift
+            {"id": 3, "date": "2023-01-03", "title": "マミーイベント2", "category": "マミー系"},
+        ]
+        violations = calendario_utils.get_specialized_schedule_violations(events_case2, sample_rules_base, mock_users_config)
+        self.assertEqual(len(violations), 1, "Test Case 2 Failed: Should be one violation.")
+        expected_msg_2 = "マミー系の予定がある日(2023-01-03)に、指定担当者 (sara, hitomi) のいずれも割り当てられていません。"
+        self.assertIn(expected_msg_2, violations, "Test Case 2 Failed: Violation message mismatch.")
+
+        # Test Case 3: No relevant specialized events
+        events_case3 = [
+            {"date": "2023-01-01", "category": "shift", "employee": "sara"},
+            {"id": 4, "date": "2023-01-04", "title": "通常イベント", "category": "other"},
+        ]
+        violations = calendario_utils.get_specialized_schedule_violations(events_case3, sample_rules_base, mock_users_config)
+        self.assertEqual(len(violations), 0, "Test Case 3 Failed: No specialized events, should be no violations.")
+
+        # Test Case 4: Event exists but no rule for its category
+        events_case4 = [
+            {"date": "2023-01-01", "category": "shift", "employee": "sara"},
+            {"id": 1, "date": "2023-01-01", "title": "マミーイベント1", "category": "マミー系"},
+        ]
+        rules_case4 = {"specialized_requirements": {"タトゥー": ["jun"]}} # No rule for マミー系
+        violations = calendario_utils.get_specialized_schedule_violations(events_case4, rules_case4, mock_users_config)
+        self.assertEqual(len(violations), 0, "Test Case 4 Failed: Event category not in rules, should be no violation.")
+
+        # Test Case 5: Staff on shift but not the designated one for that genre
+        # マミー系 requires sara or hitomi. jun is on shift for タトゥー event. This is fine.
+        # Let's test a マミー系 event where 'jun' is on shift, but 'sara'/'hitomi' are required.
+        events_case5 = [
+            {"date": "2023-01-02", "category": "shift", "employee": "jun"}, # Jun is on shift
+            {"id": 1, "date": "2023-01-02", "title": "マミーイベント強制", "category": "マミー系"}, # マミー系 event
+        ]
+        violations = calendario_utils.get_specialized_schedule_violations(events_case5, sample_rules_base, mock_users_config)
+        self.assertEqual(len(violations), 1, "Test Case 5 Failed: Jun is on shift, but not designated for マミー系.")
+        expected_msg_5 = "マミー系の予定がある日(2023-01-02)に、指定担当者 (sara, hitomi) のいずれも割り当てられていません。"
+        self.assertIn(expected_msg_5, violations, "Test Case 5 Failed: Violation message mismatch.")
+
+        # Test Case 6: No one on shift for a specialized event day
+        events_case6 = [
+             # No shifts on 2023-01-05
+            {"id": 5, "date": "2023-01-05", "title": "マミーイベント3無人", "category": "マミー系"},
+        ]
+        violations = calendario_utils.get_specialized_schedule_violations(events_case6, sample_rules_base, mock_users_config)
+        self.assertEqual(len(violations), 1, "Test Case 6 Failed: No one on shift for a マミー系 event.")
+        expected_msg_6 = "マミー系の予定がある日(2023-01-05)に、指定担当者 (sara, hitomi) のいずれも割り当てられていません。"
+        self.assertIn(expected_msg_6, violations, "Test Case 6 Failed: Violation message mismatch.")
+
+        # Test Case 7: Rule exists, but the list of designated staff is empty
+        events_case7 = [
+            {"date": "2023-01-01", "category": "shift", "employee": "sara"},
+            {"id": 1, "date": "2023-01-01", "title": "マミーイベント1", "category": "マミー系"},
+        ]
+        rules_case7 = {"specialized_requirements": {"マミー系": []}} # Empty designated list
+        violations = calendario_utils.get_specialized_schedule_violations(events_case7, rules_case7, mock_users_config)
+        self.assertEqual(len(violations), 0, "Test Case 7 Failed: Empty designated staff list should not cause violation.")
+
+        # Test Case 8: Specialized requirements empty in rules
+        rules_case8 = {"specialized_requirements": {}}
+        violations = calendario_utils.get_specialized_schedule_violations(sample_events_base, rules_case8, mock_users_config)
+        self.assertEqual(len(violations), 0, "Test Case 8 Failed: Empty specialized_requirements object should lead to no violations.")
+
+        # Test Case 9: Rule value is not a list (should be handled gracefully)
+        events_case9 = sample_events_base
+        rules_case9 = {"specialized_requirements": {"マミー系": "sara"}} # "sara" instead of ["sara"]
+        # Expecting it to print a warning and skip this rule, not crash.
+        violations = calendario_utils.get_specialized_schedule_violations(events_case9, rules_case9, mock_users_config)
+        # Depending on how it's handled: if it skips, events requiring "マミー系" might show violations or not.
+        # The current implementation of get_specialized_schedule_violations prints a warning and skips.
+        # So, "マミー系" events will effectively have no valid rule and thus no violations from this malformed rule.
+        # Let's verify no violation *due to this malformed rule*.
+        # If "sara" was on shift for event on 2023-01-01, it would be 0.
+        # If "ken" was on shift for event on 2023-01-03, it would also be 0 because the rule for マミー系 is skipped.
+
+        # Let's check specific event on 2023-01-03 (マミーイベント2) where ken is on shift.
+        # If the rule was `{"マミー系": ["sara", "hitomi"]}`, this would be a violation.
+        # Since the rule `{"マミー系": "sara"}` is skipped, there's no *valid* rule for マミー系.
+        # Therefore, no violation should be reported for マミー系 events.
+        test_event_for_case9 = [e for e in events_case9 if e['id'] == 3 or (e['date'] == '2023-01-03' and e['category'] == 'shift')]
+        violations_for_case9_event3 = calendario_utils.get_specialized_schedule_violations(test_event_for_case9, rules_case9, mock_users_config)
+        self.assertEqual(len(violations_for_case9_event3), 0, "Test Case 9 Failed: Malformed rule should be skipped, resulting in no violation for that category.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…prove month view

This commit introduces several enhancements to the Calendario module:

1.  **New Event Genres:**
    *   Added "マミー系" (Mommy-kei) and "タトゥー" (Tattoo) as new event categories.
    *   These genres support time settings (start/end time).
    *   Updated `EventForm` and relevant template JavaScript (`event_form.html`) to include these new genres and manage time field visibility.

2.  **Specialized Schedule Functionality (専門予定):**
    *   Allows defining specific staff requirements for certain event genres (e.g., "マミー系" event requires "sara" or "hitomi" to be on shift).
    *   Added UI in `shift_rules.html` to manage these rules (add/delete).
        *   Rules are stored in `calendar_rules.json` under the `specialized_requirements` key.
    *   Implemented `utils.get_specialized_schedule_violations()` to detect violations.
    *   Warnings for these violations are now displayed on the shift management page (`shift_manager.html`).

3.  **Improved Month View Event Display:**
    *   The calendar month view now correctly fetches and displays events scheduled on the leading/trailing days of adjacent months that are visible in the grid.
    *   Modified event filtering logic in the `index` route in `app/calendario/routes.py`.

4.  **Tests:**
    *   Added unit tests for `utils.get_specialized_schedule_violations()`.
    *   Added integration tests covering:
        *   Creation and editing of events with the new genres.
        *   Saving and loading of specialized schedule rules.
        *   Display of specialized schedule violation warnings.
        *   Correct event visibility for adjacent month days in the month view.

These changes address the requirements outlined in the issue, providing more flexibility in event scheduling and rule management.