### PR TITLE
Fix: Restore and enhance calendar event button functionality

### DIFF
--- a/app/calendario/templates/calendario/month_view.html
+++ b/app/calendario/templates/calendario/month_view.html
@@ -72,11 +72,13 @@
                                         {{ ev.cleaned_title or ev.title }}
                                     </div>
                                     <div class="event-buttons">
-                                        <button type="button" class="btn btn-sm btn-info event-details-btn"
+                                        <button type="button" class="btn btn-sm btn-info btn-event-details"
                                                 data-event-id="{{ ev.id }}">詳細</button>
-                                        <button type="button" class="btn btn-sm btn-primary event-edit-btn"
+                                        <button type="button" class="btn btn-sm btn-primary btn-event-edit"
                                                 data-event-id="{{ ev.id }}">編集</button>
-                                        <button type="button" class="btn btn-sm btn-warning event-move-btn"
+                                        <button type="button" class="btn btn-sm btn-success btn-event-copy"
+                                                data-event-id="{{ ev.id }}">コピー</button>
+                                        <button type="button" class="btn btn-sm btn-warning btn-event-move"
                                                 data-event-id="{{ ev.id }}">移動</button>
                                     </div>
                                 </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -771,6 +771,7 @@ select.time-select, select[name="start_time"], select[name="end_time"] {
     display: block; /* flexではなくblock */
     width: calc(100% - 10px); /* セル内で適切な幅を確保 */
     max-width: 190px; /* 最大幅を制限 */
+    padding-right: 160px !important; /* 4つのボタン分のスペース */
 }
 
 .event-content-wrapper {
@@ -790,15 +791,15 @@ select.time-select, select[name="start_time"], select[name="end_time"] {
 
 .event-buttons {
     display: flex;
-    gap: 2px;
+    gap: 1px !important; /* ボタン間隔をさらに狭く */
     justify-content: flex-start; /* 左寄せ */
     flex-wrap: nowrap; /* ボタンが折り返さない */
 }
 
 /* 各ボタンのサイズ調整 */
 .event-buttons .btn {
-    padding: 2px 6px;
-    font-size: 11px;
+    padding: 1px 5px !important; /* さらに小さく */
+    font-size: 11px !important;
     line-height: 1.2;
     flex-shrink: 0; /* ボタンが縮まない */
 }
@@ -829,4 +830,9 @@ select.time-select, select[name="start_time"], select[name="end_time"] {
     .calendar-scroll-container {
         overflow-x: visible !important; /* 大画面ではスクロール不要 */
     }
+}
+
+.moving-mode {
+    opacity: 0.6;
+    border: 2px dashed #007bff;
 }

--- a/static/js/calendario.js
+++ b/static/js/calendario.js
@@ -6,84 +6,44 @@ if (typeof window.editEvent === 'undefined') {
     };
 }
 
-// static/js/calendario.js (前回作成したものを修正)
+// Existing global functions from calendario.js
 function showEventDetails(eventId, cellElement) {
-    // 既存のポップアップを削除 (showCalendarioPopupが行うので、ここでは不要かもしれないが念のため)
     $('.event-popup').remove();
-    $('.warning-popup').remove(); // 他のポップアップも消すなら (showCalendarioPopupはevent-popupのみを対象とする)
-                                  // showCalendarioPopup 自体が $('.event-popup').remove(); を実行するので、
-                                  // ここでの .event-popup の削除は重複するが、害は少ない。
-                                  // warning-popup など他のクラスも消したい場合は個別に追加する。
+    $('.warning-popup').remove();
 
-    // APIからデータを取得
     $.get(`/calendario/event/${eventId}/details`, function(data) {
         if (data.error) {
             console.error("Error fetching event details:", data.error);
             const errorTitle = "エラー";
             const errorHtml = `<p>詳細の取得に失敗しました: ${data.error}</p>`;
-            // showCalendarioPopup は targetElement を期待する
-            // cellElement がDOM要素であることを確認
             showCalendarioPopup(errorTitle, errorHtml, cellElement instanceof jQuery ? cellElement[0] : cellElement, 'error-popup');
             return;
         }
-
         const title = data.title || '予定の詳細';
-        // contentHtml には閉じるボタンは不要 (showCalendarioPopupが自動で追加するため)
         const contentHtml = `
             <p><strong>日時:</strong> ${data.date} ${data.time || ''}</p>
             <p><strong>種類:</strong> ${data.genre}</p>
             <p><strong>説明:</strong> ${data.description || 'なし'}</p>
             <p><strong>担当:</strong> ${data.employee || ''}</p>
         `;
-
-        // 既存の showCalendarioPopup を呼び出す
-        // targetElement として cellElement を渡す
-        // additionalClass は適宜設定 (例: 'event-details-popup')
-        // cellElement がjQueryオブジェクトの場合、DOM要素を渡す
         showCalendarioPopup(title, contentHtml, cellElement instanceof jQuery ? cellElement[0] : cellElement, 'event-details-popup');
-
     }).fail(function(jqXHR, textStatus, errorThrown) {
         console.error("Failed to fetch event details:", textStatus, errorThrown);
         const errorTitle = "エラー";
         const errorHtml = `<p>イベント詳細の取得に失敗しました。サーバーエラーが発生した可能性があります。</p>`;
-        // showCalendarioPopup は targetElement を期待する
-        // cellElement がDOM要素であることを確認
         showCalendarioPopup(errorTitle, errorHtml, cellElement instanceof jQuery ? cellElement[0] : cellElement, 'error-popup');
     });
 }
 
-// Ensure jQuery is available, otherwise this code will not work.
-// This script assumes jQuery is loaded globally.
-// Ensure showCalendarioPopup function is available (e.g., loaded from calendar_event_details.js or a shared utility script)
-// and that it is loaded BEFORE this script if in separate files.
-
-
-// static/js/calendario.js (既存の showEventDetails の下などに追加)
-
 function showWarningDetails(warningType, details, cellElement) {
-    // 既存のポップアップを削除 (showCalendarioPopupが行うので、ここでは不要かもしれないが念のため)
-    // showCalendarioPopup は .event-popup を削除するので、warning-popup も削除対象に含める
     $('.event-popup').remove();
-    $('.warning-popup').remove(); // 自分自身も消す
-
-    const title = '<h5 style="color: #856404;">⚠️ ルール違反</h5>'; // タイトルは固定または warningType に応じて変更
+    $('.warning-popup').remove();
+    const title = '<h5 style="color: #856404;">⚠️ ルール違反</h5>';
     const contentHtml = `<p>${details}</p>`;
-
-    // 既存の showCalendarioPopup を呼び出す
-    // targetElement として cellElement を渡す
-    // additionalClass として 'warning-popup' や、warningType に応じたクラスを指定可能
-    let popupClass = 'warning-popup';
-    // if (warningType === 'someSpecificType') {
-    //     popupClass += ' specific-warning-class';
-    // }
-
-    // showCalendarioPopup は targetElement として DOM Element を期待する
     const targetDomElement = (cellElement instanceof jQuery) ? cellElement[0] : cellElement;
-
-    showCalendarioPopup(title, contentHtml, targetDomElement, popupClass);
+    showCalendarioPopup(title, contentHtml, targetDomElement, 'warning-popup');
 }
 
-// Function to truncate long event titles
 function truncateEventTitle(title, maxLength = 20) {
     if (title.length > maxLength) {
         return title.substring(0, maxLength) + '...';
@@ -91,61 +51,128 @@ function truncateEventTitle(title, maxLength = 20) {
     return title;
 }
 
-$(document).ready(function() {
-    // Details Button
-    $(document).on('click', '.event-details-btn', function(e) {
+// New event handlers wrapped in DOMContentLoaded
+document.addEventListener('DOMContentLoaded', function() {
+    // Details Button for non-shift events
+    $(document).on('click', '.btn-event-details', function(e) {
         e.preventDefault();
-        e.stopPropagation();
         const eventId = $(this).data('event-id');
-        const cellElement = $(this).closest('td')[0]; // Get the raw DOM element
+        const cellElement = $(this).closest('td')[0];
         if (typeof showEventDetails === 'function') {
             showEventDetails(eventId, cellElement);
         } else {
-            console.error('showEventDetails function is not defined for event ID:', eventId);
+            console.error('showEventDetails function is not defined.');
         }
     });
 
-    // Edit Button
-    $(document).on('click', '.event-edit-btn', function(e) {
+    // Edit Button for non-shift events
+    $(document).on('click', '.btn-event-edit', function(e) {
         e.preventDefault();
-        e.stopPropagation();
         const eventId = $(this).data('event-id');
-        if (typeof editEvent === 'function') { // This refers to window.editEvent
+        if (typeof editEvent === 'function') {
             editEvent(eventId);
         } else {
-            // This else block should ideally not be reached if window.editEvent is correctly defined.
-            console.error('Global editEvent function is not defined. Attempting direct navigation for event ID:', eventId);
-            window.location.href = `/calendario/edit/${eventId}`; // Fallback
+            console.error('Global editEvent function is not defined. Attempting direct navigation.');
+            window.location.href = `/calendario/edit/${eventId}`;
         }
     });
 
-    // Move Button
-    $(document).on('click', '.event-move-btn', function(e) {
+    // Copy Button for non-shift events
+    $(document).on('click', '.btn-event-copy', function(e) {
         e.preventDefault();
-        e.stopPropagation();
         const eventId = $(this).data('event-id');
-        console.log('Move button clicked for event ID:', eventId);
-        // Placeholder for existing move functionality integration
-        // Example: if there's a global function like `initiateMoveProcess(eventId)`
-        // if (typeof initiateMoveProcess === 'function') {
-        //     initiateMoveProcess(eventId);
-        // } else {
-        //     console.warn('Move functionality not yet fully implemented for this button.');
-        // }
+        const cellElement = $(this).closest('td');
+        const currentDate = cellElement.data('date');
+
+        if (!currentDate) {
+            alert('日付が取得できませんでした。');
+            return;
+        }
+
+        if (confirm('この予定をコピーしますか？')) {
+            $.ajax({
+                url: (typeof apiEventDropUrl !== 'undefined' ? apiEventDropUrl : '/calendario/api/event/drop'),
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    event_id: eventId,
+                    new_date: currentDate,
+                    operation: 'copy'
+                }),
+                success: function(response) {
+                    alert('予定をコピーしました');
+                    location.reload();
+                },
+                error: function(xhr, status, error) {
+                    let errorMsg = 'コピーに失敗しました';
+                    if (xhr.responseJSON && xhr.responseJSON.message) {
+                        errorMsg += ': ' + xhr.responseJSON.message;
+                    } else if (error) {
+                        errorMsg += ': ' + error;
+                    }
+                    alert(errorMsg);
+                }
+            });
+        }
     });
 
-    // Shift Event Copy Button (and potentially other .btn-custom-copy buttons)
-    $(document).on('click', '.btn-custom-copy', function(e) {
+    // Move Button for non-shift events
+    $(document).on('click', '.btn-event-move', function(e) {
         e.preventDefault();
-        e.stopPropagation();
+        const $eventItem = $(this).closest('.event-item');
         const eventId = $(this).data('event-id');
-        console.log('Copy button clicked for event ID:', eventId);
-        // Placeholder for copy functionality
-        // Example: if there's a global function like `copyEvent(eventId)`
-        // if (typeof copyEvent === 'function') {
-        //     copyEvent(eventId);
-        // } else {
-        //     console.warn('Copy functionality not yet implemented for this button.');
-        // }
+
+        $eventItem.addClass('moving-mode');
+        alert('移動先の日付をクリックしてください');
+
+        $('.calendar-day').off('click.moveEvent');
+
+        $('.calendar-day').one('click.moveEvent', function() {
+            const newDate = $(this).data('date');
+            if (newDate) {
+                $.ajax({
+                    url: (typeof apiEventDropUrl !== 'undefined' ? apiEventDropUrl : '/calendario/api/event/drop'),
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify({
+                        event_id: eventId,
+                        new_date: newDate,
+                        operation: 'move'
+                    }),
+                    success: function(response) {
+                        location.reload();
+                    },
+                    error: function(xhr, status, error) {
+                        let errorMsg = '移動に失敗しました';
+                        if (xhr.responseJSON && xhr.responseJSON.message) {
+                            errorMsg += ': ' + xhr.responseJSON.message;
+                        } else if (error) {
+                            errorMsg += ': ' + error;
+                        }
+                        alert(errorMsg);
+                        $eventItem.removeClass('moving-mode');
+                    }
+                });
+            } else {
+                alert('有効な日付セルを選択してください。');
+                $eventItem.removeClass('moving-mode');
+            }
+        });
+    });
+
+    // Placeholder Handlers for Shift Event Buttons (as per previous structure in month_view)
+    // These target .btn-custom-copy and .btn-custom-move which are used by shift items
+    $(document).on('click', '.shift-grid-item .btn-custom-copy', function(e) {
+        e.preventDefault();
+        const eventId = $(this).data('event-id');
+        console.log('Shift Copy button clicked for event ID:', eventId);
+        alert('シフトのコピー機能は別途実装されます。Event ID: ' + eventId);
+    });
+
+    $(document).on('click', '.shift-grid-item .btn-custom-move', function(e) {
+        e.preventDefault();
+        const eventId = $(this).data('event-id');
+        console.log('Shift Move button clicked for event ID:', eventId);
+        alert('シフトの移動機能は別途実装されます。Event ID: ' + eventId);
     });
 });


### PR DESCRIPTION
This commit addresses urgent issues with your calendar event button actions, including adding a copy button for regular events and implementing AJAX-based copy and move operations.

**1. HTML Updates (`month_view.html`):**
    - For non-shift events, the `.event-buttons` div now includes a "Copy" button (`.btn-event-copy`).
    - Button class names for Details, Edit, and Move for non-shift events were updated to `.btn-event-details`, `.btn-event-edit`, and `.btn-event-move` respectively.
    - All buttons use `data-event-id` and are `type="button"`, with inline `onclick` handlers removed.

**2. JavaScript Event Handlers (`calendario.js`):**
    - Event handlers are now wrapped in `DOMContentLoaded` and use jQuery event delegation.
    - **Details Button (`.btn-event-details`):** Correctly calls `showEventDetails()`.
    - **Edit Button (`.btn-event-edit`):** Correctly calls the global `editEvent()` function for navigation.
    - **Copy Button (`.btn-event-copy`):**
        - Prompts you for confirmation.
        - Performs an AJAX POST to `apiEventDropUrl` with `operation: 'copy'`, using the event's current date. - Reloads page on successful copy, shows alert on error.
    - **Move Button (`.btn-event-move`):** - Activates a "moving mode" (adds `.moving-mode` class to item, shows alert). - Attaches a one-time click listener to `.calendar-day` cells. - On day cell click, performs an AJAX POST to `apiEventDropUrl` with `operation: 'move'`, using the selected new date. - Reloads page on successful move, shows alert and removes moving mode on error.
    - **Shift Event Buttons (`.shift-grid-item .btn-custom-copy`, `.shift-grid-item .btn-custom-move`):**
        - Basic click handlers implemented (currently log to console and alert as placeholders for specific shift copy/move logic).
    - Ensured `window.editEvent` is globally defined for navigation.
    - AJAX calls use `apiEventDropUrl` (if defined) or a fallback URL.

**3. CSS Adjustments (`style.css`):**
    - Added styles for the `.moving-mode` class (opacity, dashed border) for visual feedback.
    - Adjusted `.event-item` with `padding-right: 160px !important;` as per your feedback (note: interaction with flex column layout of child elements needs to be considered).
    - Fine-tuned `.event-buttons` with `gap: 1px !important;`.
    - Adjusted `.event-buttons .btn` with `padding: 1px 5px !important;` and `font-size: 11px !important;` for more compact buttons.

These changes are critical for restoring core event management functionality (Details, Edit) and implementing the requested Copy and interactive Move features for regular calendar events.